### PR TITLE
Add phpstan checks

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,0 +1,12 @@
+on: [push, pull_request]
+name: Quality assurance
+jobs:
+  phpstan:
+    name: PHPStan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: PHPStan
+        uses: "docker://oskarstark/phpstan-ga"
+        with:
+          args: analyse

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     ],
     "require": {
         "php": "^7.1",
+        "jms/metadata": "^2.1",
         "symfony/event-dispatcher": "^3.4 || ^4.0",
         "symfony/form": "^3.4.24 || ^4.2.5",
         "symfony/options-resolver": "^3.4 || ^4.0",
@@ -34,6 +35,7 @@
         "sonata-project/core-bundle": ">=3.13"
     },
     "require-dev": {
+        "doctrine/persistence": "^1.1",
         "matthiasnoback/symfony-config-test": "^4.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
         "symfony/config": "^3.4 || ^4.0",
@@ -43,6 +45,9 @@
         "symfony/http-kernel": "^3.4 || ^4.0",
         "symfony/phpunit-bridge": "^4.1",
         "symfony/twig-bridge": "^3.4 || ^4.1"
+    },
+    "suggest": {
+        "doctrine/persistence": "If you want to use BaseDoctrineORMSerializationType"
     },
     "config": {
         "sort-packages": true

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,17 @@
+parameters:
+    level: 1
+
+    paths:
+        - src
+# Uncomment this, when phpstan extensions are allowed
+#        - tests
+
+    excludes_analyse:
+        - src/Test/AbstractWidgetTestCase.php
+        - tests/bootstrap.php
+
+    autoload_files:
+        - vendor/autoload.php
+
+    ignoreErrors:
+        - '#Class Sonata\\Form\\Validator\\LegacyExecutionContextInterface not found.#'

--- a/src/Type/BaseDoctrineORMSerializationType.php
+++ b/src/Type/BaseDoctrineORMSerializationType.php
@@ -21,7 +21,6 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * This is a doctrine serialization form type that generates a form type from class serialization metadata
@@ -146,16 +145,6 @@ class BaseDoctrineORMSerializationType extends AbstractType
     public function getName()
     {
         return $this->getBlockPrefix();
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @todo Remove it when bumping requirements to SF 2.7+
-     */
-    public function setDefaultOptions(OptionsResolverInterface $resolver): void
-    {
-        $this->configureOptions($resolver);
     }
 
     public function configureOptions(OptionsResolver $resolver): void


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Improve code quality by running phpstan 🚀 

The removed method was never callable, because the `OptionsResolverInterface` class does not exist is symfony 3+

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is will help to improve code quality for the stable branch.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Remove `BaseDoctrineORMSerializationType::setDefaultOptions`
```
