### PR TITLE
Add support for current symfony/twig versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "jms/metadata": "^2.1",
         "symfony/event-dispatcher": "^3.4 || ^4.2 || ^5.0",
         "symfony/form": "^3.4.24 || ^4.2.5 || ^5.0",
+        "symfony/intl": "^3.4 || ^4.2 || ^5.0",
         "symfony/options-resolver": "^3.4 || ^4.2 || ^5.0",
         "symfony/property-access": "^3.4 || ^4.2 || ^5.0",
         "symfony/security-csrf": "^3.4 || ^4.2 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "symfony/security-csrf": "^3.4 || ^4.2 || ^5.0",
         "symfony/translation": "^3.4 || ^4.2 || ^5.0",
         "symfony/validator": "^3.4 || ^4.2 || ^5.0",
-        "twig/twig": "^2.0"
+        "twig/twig": "^2.7 || ^3.0"
     },
     "conflict": {
         "sonata-project/core-bundle": ">=3.13"

--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,13 @@
     "require": {
         "php": "^7.1",
         "jms/metadata": "^2.1",
-        "symfony/event-dispatcher": "^3.4 || ^4.0",
-        "symfony/form": "^3.4.24 || ^4.2.5",
-        "symfony/options-resolver": "^3.4 || ^4.0",
-        "symfony/property-access": "^3.4 || ^4.0",
-        "symfony/security-csrf": "^3.4 || ^4.0",
-        "symfony/translation": "^3.4 || ^4.0",
-        "symfony/validator": "^3.4 || ^4.0",
+        "symfony/event-dispatcher": "^3.4 || ^4.2 || ^5.0",
+        "symfony/form": "^3.4.24 || ^4.2.5 || ^5.0",
+        "symfony/options-resolver": "^3.4 || ^4.2 || ^5.0",
+        "symfony/property-access": "^3.4 || ^4.2 || ^5.0",
+        "symfony/security-csrf": "^3.4 || ^4.2 || ^5.0",
+        "symfony/translation": "^3.4 || ^4.2 || ^5.0",
+        "symfony/validator": "^3.4 || ^4.2 || ^5.0",
         "twig/twig": "^2.0"
     },
     "conflict": {
@@ -38,13 +38,13 @@
         "doctrine/persistence": "^1.1",
         "matthiasnoback/symfony-config-test": "^4.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
-        "symfony/config": "^3.4 || ^4.0",
-        "symfony/dependency-injection": "^3.4 || ^4.0",
-        "symfony/framework-bundle": "^3.4 || ^4.0",
-        "symfony/http-foundation": "^3.4 || ^4.0",
-        "symfony/http-kernel": "^3.4 || ^4.0",
-        "symfony/phpunit-bridge": "^4.1",
-        "symfony/twig-bridge": "^3.4 || ^4.1"
+        "symfony/config": "^3.4 || ^4.2 || ^5.0",
+        "symfony/dependency-injection": "^3.4 || ^4.2 || ^5.0",
+        "symfony/framework-bundle": "^3.4 || ^4.2 || ^5.0",
+        "symfony/http-foundation": "^3.4 || ^4.2 || ^5.0",
+        "symfony/http-kernel": "^3.4 || ^4.2 || ^5.0",
+        "symfony/phpunit-bridge": "^5.0",
+        "symfony/twig-bridge": "^3.4 || ^4.1 || ^5.0"
     },
     "suggest": {
         "doctrine/persistence": "If you want to use BaseDoctrineORMSerializationType"

--- a/src/Fixtures/StubFilesystemLoader.php
+++ b/src/Fixtures/StubFilesystemLoader.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Form\Fixtures;
+
+use Twig\Loader\FilesystemLoader;
+
+final class StubFilesystemLoader extends FilesystemLoader
+{
+    protected function findTemplate($name, $throw = true)
+    {
+        // strip away bundle name
+        $parts = explode(':', $name);
+
+        return parent::findTemplate(end($parts), $throw);
+    }
+}

--- a/src/Fixtures/StubTranslator.php
+++ b/src/Fixtures/StubTranslator.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Form\Fixtures;
+
+use Symfony\Component\Translation\TranslatorInterface as LegacyTranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+if (interface_exists(TranslatorInterface::class)) {
+    final class StubTranslator implements TranslatorInterface
+    {
+        public function trans($id, array $parameters = [], $domain = null, $locale = null): string
+        {
+            return '[trans]'.strtr($id, $parameters).'[/trans]';
+        }
+    }
+} else {
+    final class StubTranslator implements LegacyTranslatorInterface
+    {
+        public function trans($id, array $parameters = [], $domain = null, $locale = null)
+        {
+            return '[trans]'.$id.'[/trans]';
+        }
+
+        public function transChoice($id, $number, array $parameters = [], $domain = null, $locale = null)
+        {
+            return '[trans]'.$id.'[/trans]';
+        }
+
+        public function setLocale($locale)
+        {
+        }
+
+        public function getLocale()
+        {
+        }
+    }
+}

--- a/src/Test/AbstractWidgetTestCase.php
+++ b/src/Test/AbstractWidgetTestCase.php
@@ -72,7 +72,7 @@ abstract class AbstractWidgetTestCase extends TypeTestCase
         return $this->renderer;
     }
 
-    final protected function getEnvironment(): \Twig_Environment
+    final protected function getEnvironment(): Environment
     {
         $loader = new StubFilesystemLoader($this->getTemplatePaths());
 
@@ -109,7 +109,7 @@ abstract class AbstractWidgetTestCase extends TypeTestCase
         return $twigPaths;
     }
 
-    final protected function getRenderingEngine(\Twig_Environment $environment): TwigRendererEngine
+    final protected function getRenderingEngine(Environment $environment): TwigRendererEngine
     {
         return new TwigRendererEngine(['form_div_layout.html.twig'], $environment);
     }

--- a/src/Test/AbstractWidgetTestCase.php
+++ b/src/Test/AbstractWidgetTestCase.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace Sonata\Form\Test;
 
+use Sonata\Form\Fixtures\StubFilesystemLoader;
+use Sonata\Form\Fixtures\StubTranslator;
 use Symfony\Bridge\Twig\Extension\FormExtension;
 use Symfony\Bridge\Twig\Extension\TranslationExtension;
 use Symfony\Bridge\Twig\Form\TwigRendererEngine;
-use Symfony\Bridge\Twig\Tests\Extension\Fixtures\StubFilesystemLoader;
-use Symfony\Bundle\FrameworkBundle\Tests\Templating\Helper\Fixtures\StubTranslator;
 use Symfony\Component\Form\FormExtensionInterface;
 use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\Form\FormView;

--- a/src/Type/BasePickerType.php
+++ b/src/Type/BasePickerType.php
@@ -18,6 +18,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\Intl\DateFormatter\IntlDateFormatter;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -91,10 +92,10 @@ abstract class BasePickerType extends AbstractType
         $options['dp_use_seconds'] = false !== strpos($format, 's');
 
         if ($options['dp_min_date'] instanceof \DateTime) {
-            $options['dp_min_date'] = \IntlDateFormatter::formatObject($options['dp_min_date'], $format, $this->locale);
+            $options['dp_min_date'] = $this->formatObject($options['dp_min_date'], $format);
         }
         if ($options['dp_max_date'] instanceof \DateTime) {
-            $options['dp_max_date'] = \IntlDateFormatter::formatObject($options['dp_max_date'], $format, $this->locale);
+            $options['dp_max_date'] = $this->formatObject($options['dp_max_date'], $format);
         }
 
         $view->vars['moment_format'] = $this->formatConverter->convert($format);
@@ -150,5 +151,12 @@ abstract class BasePickerType extends AbstractType
             'dp_view_mode' => 'days',
             'dp_min_view_mode' => 'days',
         ];
+    }
+
+    private function formatObject(\DateTime $dateTime, string $format): string
+    {
+        $formatter = new IntlDateFormatter($this->locale);
+
+        return $formatter->formatObject($dateTime, $format);
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/form-extensions/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/form-extensions/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added support for symfony 5
- Added support for twig 3

### Removed
- Removed support for symfony 4.0, 4.1
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
