### PR TITLE
Deprecate Sonata ResizeFormListener and use Symfony one

### DIFF
--- a/docs/reference/form_types.rst
+++ b/docs/reference/form_types.rst
@@ -191,11 +191,6 @@ btn_add and btn_catalogue:
 type_options:
   This array is passed to the underlying forms.
 
-pre_bind_data_callback:
-  This closure will be executed during the preBind method (``FormEvent::PRE_BIND`` | ``FormEvent::PRE_SUBMIT``)
-  to build the data given to the form based on the value retrieved. Use this if you need to generate your forms based
-  on the submitted data.
-
 .. tip::
 
     A jQuery event is fired after a row has been added (``sonata-admin-append-form-element``).

--- a/src/Type/CollectionType.php
+++ b/src/Type/CollectionType.php
@@ -29,7 +29,7 @@ final class CollectionType extends AbstractType
             $options['type'],
             $options['type_options'],
             $options['modifiable'],
-            $options['pre_bind_data_callback']
+            $options['modifiable']
         ));
     }
 
@@ -45,7 +45,7 @@ final class CollectionType extends AbstractType
             'modifiable' => false,
             'type' => TextType::class,
             'type_options' => [],
-            'pre_bind_data_callback' => null,
+            'pre_bind_data_callback' => null, // NEXT_MAJOR: Remove this default value
             'btn_add' => 'link_add',
             'btn_catalogue' => 'SonataFormBundle',
         ]);

--- a/tests/EventListener/ResizeFormListenerTest.php
+++ b/tests/EventListener/ResizeFormListenerTest.php
@@ -25,6 +25,9 @@ use Symfony\Component\Form\FormEvents;
  */
 class ResizeFormListenerTest extends TestCase
 {
+    /**
+     * @group legacy
+     */
     public function testGetSubscribedEvents(): void
     {
         $events = ResizeFormListener::getSubscribedEvents();
@@ -37,6 +40,9 @@ class ResizeFormListenerTest extends TestCase
         $this->assertSame('onSubmit', $events[FormEvents::SUBMIT]);
     }
 
+    /**
+     * @group legacy
+     */
     public function testPreSetDataWithNullData(): void
     {
         $listener = new ResizeFormListener('form', [], false, null);
@@ -53,6 +59,9 @@ class ResizeFormListenerTest extends TestCase
         $listener->preSetData($event);
     }
 
+    /**
+     * @group legacy
+     */
     public function testPreSetDataThrowsExceptionWithStringEventData(): void
     {
         $listener = new ResizeFormListener('form', [], false, null);
@@ -66,6 +75,9 @@ class ResizeFormListenerTest extends TestCase
         $listener->preSetData($event);
     }
 
+    /**
+     * @group legacy
+     */
     public function testPreSetData(): void
     {
         $typeOptions = [
@@ -98,6 +110,9 @@ class ResizeFormListenerTest extends TestCase
         $listener->preSetData($event);
     }
 
+    /**
+     * @group legacy
+     */
     public function testPreSubmitWithResizeOnBindFalse(): void
     {
         $listener = new ResizeFormListener('form', [], false, null);
@@ -109,6 +124,9 @@ class ResizeFormListenerTest extends TestCase
         $listener->preSubmit($event);
     }
 
+    /**
+     * @group legacy
+     */
     public function testPreSubmitDataWithNullData(): void
     {
         $listener = new ResizeFormListener('form', [], true, null);
@@ -125,6 +143,9 @@ class ResizeFormListenerTest extends TestCase
         $listener->preSubmit($event);
     }
 
+    /**
+     * @group legacy
+     */
     public function testPreSubmitThrowsExceptionWithIntEventData(): void
     {
         $listener = new ResizeFormListener('form', [], true, null);
@@ -137,6 +158,9 @@ class ResizeFormListenerTest extends TestCase
         $listener->preSubmit($event);
     }
 
+    /**
+     * @group legacy
+     */
     public function testPreSubmitData(): void
     {
         $typeOptions = [
@@ -168,6 +192,9 @@ class ResizeFormListenerTest extends TestCase
         $listener->preSubmit($event);
     }
 
+    /**
+     * @group legacy
+     */
     public function testPreSubmitDataWithClosure(): void
     {
         $typeOptions = [
@@ -204,6 +231,9 @@ class ResizeFormListenerTest extends TestCase
         $listener->preSubmit($event);
     }
 
+    /**
+     * @group legacy
+     */
     public function testOnSubmitWithResizeOnBindFalse(): void
     {
         $listener = new ResizeFormListener('form', [], false, null);
@@ -215,6 +245,9 @@ class ResizeFormListenerTest extends TestCase
         $listener->onSubmit($event);
     }
 
+    /**
+     * @group legacy
+     */
     public function testOnSubmitDataWithNullData(): void
     {
         $listener = new ResizeFormListener('form', [], true, null);
@@ -228,6 +261,9 @@ class ResizeFormListenerTest extends TestCase
         $listener->onSubmit($event);
     }
 
+    /**
+     * @group legacy
+     */
     public function testOnSubmitThrowsExceptionWithIntEventData(): void
     {
         $listener = new ResizeFormListener('form', [], true, null);
@@ -241,6 +277,9 @@ class ResizeFormListenerTest extends TestCase
         $listener->onSubmit($event);
     }
 
+    /**
+     * @group legacy
+     */
     public function testOnSubmit(): void
     {
         $listener = new ResizeFormListener('form', [], true, null);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

When working on this PR https://github.com/sonata-project/SonataAdminBundle/pull/5942, I ended in the AdminType with a FormBuilder without data https://github.com/sonata-project/SonataAdminBundle/blob/3c2f0f1a7b9fea27445b14b5a5a00277ed7106a0/src/Form/Type/AdminType.php#L55

I discovered this was related to the resizeFormListener because it's removing the data on PreSubmit https://github.com/sonata-project/form-extensions/blob/1.x/src/EventListener/ResizeFormListener.php#L139

I also discovered that there is a really really similar resizeFormListener provided by Symfony and written by the same author than the one in Sonata project Bernhard Schussek.

Unfortunaly, that does not seems to help me, but I don't see any reason for not deprecating our resizeFormListener and using the Symfony one.

## Changelog

```markdown
### Deprecated
- Deprecate the Sonata\Form\EventListener\ResizeFormListener in favor of Symfony\Component\Form\Extension\Core\EventListener\ResizeFormListener
```