### PR TITLE
Downgrade to use in Sonata 3

### DIFF
--- a/src/Bridge/Symfony/Bundle/SonataFormBundle.php
+++ b/src/Bridge/Symfony/Bundle/SonataFormBundle.php
@@ -16,10 +16,13 @@ namespace Sonata\Form\Bridge\Symfony\Bundle;
 use Sonata\Form\Bridge\Symfony\DependencyInjection\SonataFormExtension;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
+/**
+ * @deprecated Since version 1.x, to be removed in 2.0. Use Sonata\Form\Bridge\Symfony\SonataFormBundle instead.
+ */
 final class SonataFormBundle extends Bundle
 {
     /**
-     * {@inheritdoc}
+     * @return string
      */
     public function getPath()
     {
@@ -27,7 +30,7 @@ final class SonataFormBundle extends Bundle
     }
 
     /**
-     * {@inheritdoc}
+     * @return string
      */
     protected function getContainerExtensionClass()
     {

--- a/src/Bridge/Symfony/SonataFormBundle.php
+++ b/src/Bridge/Symfony/SonataFormBundle.php
@@ -11,17 +11,18 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Sonata\Form\Serializer;
+namespace Sonata\Form\Bridge\Symfony;
 
-use JMS\Serializer\Handler\SubscribingHandlerInterface;
+use Sonata\Form\Bridge\Symfony\DependencyInjection\SonataFormExtension;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-/**
- * @author Sylvain Deloux <sylvain.deloux@ekino.com>
- */
-interface SerializerHandlerInterface extends SubscribingHandlerInterface
+final class SonataFormBundle extends Bundle
 {
     /**
      * @return string
      */
-    public static function getType();
+    protected function getContainerExtensionClass()
+    {
+        return SonataFormExtension::class;
+    }
 }

--- a/src/Serializer/BaseSerializerHandler.php
+++ b/src/Serializer/BaseSerializerHandler.php
@@ -74,8 +74,10 @@ abstract class BaseSerializerHandler implements SerializerHandlerInterface
 
     /**
      * Serialize data object to id.
+     *
+     * @return int|null
      */
-    public function serializeObjectToId(VisitorInterface $visitor, object $data, array $type, Context $context): ?int
+    public function serializeObjectToId(VisitorInterface $visitor, object $data, array $type, Context $context)
     {
         $className = $this->manager->getClass();
 

--- a/src/Type/BaseStatusType.php
+++ b/src/Type/BaseStatusType.php
@@ -51,7 +51,10 @@ abstract class BaseStatusType extends AbstractType
         return $this->name;
     }
 
-    public function configureOptions(OptionsResolver $resolver): void
+    /**
+     * @return void
+     */
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
             'choices' => \call_user_func([$this->class, $this->getter]),


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/form-extensions/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Part of https://github.com/sonata-project/dev-kit/issues/697

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/form-extensions/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- add `Sonata\Form\Bridge\Symfony\Bundle\SonataFormBundle`
### Deprecated
- deprecated `Sonata\Form\Bridge\Symfony\Bundle\SonataFormBundle`. Use `Sonata\Form\Bridge\Symfony\Bundle\SonataFormBundle` instead.
### Removed
- remove return type hints in `Sonata\Form\Serializer\BaseSerializerHandler::serializeObjectToId()`
- remove return type hints in `Sonata\Form\Serializer\SerializerHandlerIntertface::getType()`
- remove return type hints in `Sonata\Form\Type\BaseStatusType::configureOptions()`

```

