### PR TITLE
Fix validator

### DIFF
--- a/src/Validator/InlineValidator.php
+++ b/src/Validator/InlineValidator.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\Form\Validator;
 
+use Sonata\CoreBundle\Validator\ErrorElement as DeprecatedErrorElement;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
@@ -65,6 +66,15 @@ class InlineValidator extends ConstraintValidator
      */
     protected function getErrorElement($value)
     {
+        if (class_exists(DeprecatedErrorElement::class)) {
+            return new DeprecatedErrorElement(
+                $value,
+                $this->constraintValidatorFactory,
+                $this->context,
+                $this->context->getGroup()
+            );
+        }
+
         return new ErrorElement(
             $value,
             $this->constraintValidatorFactory,


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->


This PR fix generating ErrorElement object. 

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/form-extensions/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/form-extensions/pull/99.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/form-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- fix validation process by use alias to generating ErrorElement in ValidatorInline when CoreBundle is register  
```

