### PR TITLE
Add `SonataFormSymfonyBundle` in order to be compatible with Symfony Flex

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "sonata-project/form-extensions",
-    "type": "symfony-bundle",
+    "type": "library",
     "description": "Symfony form extensions",
     "keywords": [
         "symfony",
@@ -61,7 +61,8 @@
     },
     "autoload": {
         "psr-4": {
-            "Sonata\\Form\\": "src/"
+            "Sonata\\Form\\": "src/",
+            "Sonata\\Form\\Bridge\\Symfony\\": "src/Bridge/Symfony/"
         }
     },
     "autoload-dev": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,6 +7,7 @@ parameters:
 #        - tests
 
     excludes_analyse:
+        - src/Bridge/Symfony/Bundle/SonataFormBundle.php
         - src/Test/AbstractWidgetTestCase.php
         - tests/bootstrap.php
 

--- a/src/Bridge/Symfony/Bundle/SonataFormBundle.php
+++ b/src/Bridge/Symfony/Bundle/SonataFormBundle.php
@@ -13,27 +13,24 @@ declare(strict_types=1);
 
 namespace Sonata\Form\Bridge\Symfony\Bundle;
 
-use Sonata\Form\Bridge\Symfony\DependencyInjection\SonataFormExtension;
+use Sonata\Form\Bridge\Symfony\SonataFormBundle;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-/**
- * @deprecated Since version 1.4, to be removed in 2.0. Use Sonata\Form\Bridge\Symfony\SonataFormBundle instead.
- */
-final class SonataFormBundle extends Bundle
-{
-    /**
-     * @return string
-     */
-    public function getPath()
-    {
-        return __DIR__.'/..';
-    }
+@trigger_error(sprintf(
+    'The %s\SonataFormBundle class is deprecated since version 1.4, to be removed in 2.0. Use %s instead.',
+    __NAMESPACE__,
+    SonataFormBundle::class
+), E_USER_DEPRECATED);
 
+if (false) {
     /**
-     * @return string
+     * NEXT_MAJOR: remove this class.
+     *
+     * @deprecated Since version 1.4, to be removed in 2.0. Use Sonata\Form\Bridge\Symfony\SonataFormBundle instead.
      */
-    protected function getContainerExtensionClass()
+    final class SonataFormBundle extends Bundle
     {
-        return SonataFormExtension::class;
     }
 }
+
+class_alias(SonataFormBundle::class, __NAMESPACE__.'\SonataFormBundle');

--- a/src/Bridge/Symfony/SonataFormSymfonyBundle.php
+++ b/src/Bridge/Symfony/SonataFormSymfonyBundle.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Form\Bridge\Symfony;
+
+// This file and its class alias is required in order to let Symfony Flex
+// autodiscovery to find the bundle.
+// The string "Symfony\Component\HttpKernel\Bundle\Bundle" must also be present.
+// @see https://github.com/symfony/flex/pull/612/files.
+class_alias(SonataFormBundle::class, __NAMESPACE__.'\SonataFormSymfonyBundle');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Add `SonataFormSymfonyBundle` in order to be compatible with Symfony Flex.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/twig-extensions/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Triggered by sonata-project/SonataAdminBundle#6173.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/twig-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `Sonata\Twig\Bridge\Symfony\SonataFormSymfonyBundle`.

### Changed
- Changed package type from "symfony-bundle" to "library".

### Fixed
- Fixed Flex recipe implementation through `SonataFormSymfonyBundle` alias.
```