### PR TITLE
Use apply tag instead of spaceless

### DIFF
--- a/src/Bridge/Symfony/Resources/views/Form/datepicker.html.twig
+++ b/src/Bridge/Symfony/Resources/views/Form/datepicker.html.twig
@@ -21,7 +21,7 @@ file that was distributed with this source code.
 {% endblock sonata_type_date_picker_widget_html %}
 
 {% block sonata_type_date_picker_widget %}
-    {% spaceless %}
+    {% apply spaceless %}
         {% if wrap_fields_with_addons %}
             <div class="input-group">
                 {{ block('sonata_type_date_picker_widget_html') }}
@@ -34,7 +34,7 @@ file that was distributed with this source code.
                 $('#{{ datepicker_use_button ? 'dp_' : '' }}{{ id }}').datetimepicker({{ dp_options|json_encode|raw }});
             });
         </script>
-    {% endspaceless %}
+    {% endapply %}
 {% endblock sonata_type_date_picker_widget %}
 
 {% block sonata_type_datetime_picker_widget_html %}
@@ -52,7 +52,7 @@ file that was distributed with this source code.
 {% endblock sonata_type_datetime_picker_widget_html %}
 
 {% block sonata_type_datetime_picker_widget %}
-    {% spaceless %}
+    {% apply spaceless %}
         {% if wrap_fields_with_addons %}
             <div class="input-group">
                 {{ block('sonata_type_datetime_picker_widget_html') }}
@@ -65,11 +65,11 @@ file that was distributed with this source code.
                 $('#{{ datepicker_use_button ? 'dtp_' : '' }}{{ id }}').datetimepicker({{ dp_options|json_encode|raw }});
             });
         </script>
-    {% endspaceless %}
+    {% endapply %}
 {% endblock sonata_type_datetime_picker_widget %}
 
 {% block sonata_type_datetime_range_script_block %}
-    {% spaceless %}
+    {% apply spaceless %}
         {{ block('form_widget') }}
         <script type="text/javascript">
             jQuery(function ($) {
@@ -83,7 +83,7 @@ file that was distributed with this source code.
                 });
             });
         </script>
-    {% endspaceless %}
+    {% endapply %}
 {% endblock sonata_type_datetime_range_script_block %}
 
 {% block sonata_type_datetime_range_picker_widget %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
This removes [`spaceless` deprecated tag](https://twig.symfony.com/doc/2.x/tags/spaceless.html).

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/form-extensions/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/form-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Replace `spaceless` deprecated tag with `apply` tag and `spaceless` filter.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
