### PR TITLE
Implement LocaleAwareInterface to remove RequestStack dependency

### DIFF
--- a/UPGRADE-1.x.md
+++ b/UPGRADE-1.x.md
@@ -1,6 +1,10 @@
 UPGRADE 1.x
 ===========
 
+## Sonata\Form\Type\BasePickerType
+
+Deprecate passing a `RequestStack` object as third parameter, you MUST pass a default locale instead.
+
 ## Deprecated EqualType form
 
 If you use `Sonata\Form\Type\EqualType`, you should use `Sonata\AdminBundle\Form\Type\Operator\EqualOperatorType` instead.

--- a/src/Bridge/Symfony/Resources/config/form_types.xml
+++ b/src/Bridge/Symfony/Resources/config/form_types.xml
@@ -20,15 +20,17 @@
         </service>
         <service id="sonata.form.type.date_picker" class="Sonata\Form\Type\DatePickerType">
             <tag name="form.type" alias="sonata_type_date_picker"/>
+            <tag name="kernel.locale_aware"/>
             <argument type="service" id="sonata.form.date.moment_format_converter"/>
             <argument type="service" id="translator"/>
-            <argument type="service" id="request_stack"/>
+            <argument>%kernel.default_locale%</argument>
         </service>
         <service id="sonata.form.type.datetime_picker" class="Sonata\Form\Type\DateTimePickerType">
             <tag name="form.type" alias="sonata_type_datetime_picker"/>
+            <tag name="kernel.locale_aware"/>
             <argument type="service" id="sonata.form.date.moment_format_converter"/>
             <argument type="service" id="translator"/>
-            <argument type="service" id="request_stack"/>
+            <argument>%kernel.default_locale%</argument>
         </service>
         <service id="sonata.form.type.date_range_picker" class="Sonata\Form\Type\DateRangePickerType">
             <tag name="form.type" alias="sonata_type_date_range_picker"/>

--- a/tests/Fixtures/Type/DummyPickerType.php
+++ b/tests/Fixtures/Type/DummyPickerType.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Form\Tests\Fixtures\Type;
+
+use Sonata\Form\Type\BasePickerType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+
+final class DummyPickerType extends BasePickerType
+{
+    public function getName()
+    {
+        return 'base_picker_test';
+    }
+
+    protected function getDefaultFormat()
+    {
+        return DateTimeType::HTML5_FORMAT;
+    }
+}

--- a/tests/Type/DatePickerTypeTest.php
+++ b/tests/Type/DatePickerTypeTest.php
@@ -13,15 +13,12 @@ declare(strict_types=1);
 
 namespace Sonata\Form\Tests\Type;
 
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use Sonata\Form\Date\MomentFormatConverter;
 use Sonata\Form\Type\DatePickerType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\PreloadedExtension;
 use Symfony\Component\Form\Test\TypeTestCase;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Translation\TranslatorInterface as LegacyTranslatorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -29,12 +26,24 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class DatePickerTypeTest extends TypeTestCase
 {
+    /**
+     * @var Stub&TranslatorInterface
+     */
+    private $translator;
+
+    protected function setUp(): void
+    {
+        $this->translator = $this->createStub(TranslatorInterface::class);
+
+        parent::setUp();
+    }
+
     public function testParentIsDateType(): void
     {
         $form = new DatePickerType(
             $this->createMock(MomentFormatConverter::class),
-            $this->getTranslatorMock(),
-            $this->getRequestStack()
+            $this->translator,
+            'en'
         );
 
         $this->assertSame(DateType::class, $form->getParent());
@@ -42,7 +51,7 @@ class DatePickerTypeTest extends TypeTestCase
 
     public function testGetName(): void
     {
-        $type = new DatePickerType(new MomentFormatConverter(), $this->getTranslatorMock(), $this->getRequestStack());
+        $type = new DatePickerType(new MomentFormatConverter(), $this->translator, 'en');
 
         $this->assertSame('sonata_type_date_picker', $type->getBlockPrefix());
     }
@@ -63,37 +72,10 @@ class DatePickerTypeTest extends TypeTestCase
 
     protected function getExtensions()
     {
-        $type = new DatePickerType(new MomentFormatConverter(), $this->getTranslatorMock(), $this->getRequestStack());
+        $type = new DatePickerType(new MomentFormatConverter(), $this->translator, 'en');
 
         return [
             new PreloadedExtension([$type], []),
         ];
-    }
-
-    /**
-     * @return MockObject|TranslatorInterface|LegacyTranslatorInterface\
-     */
-    private function getTranslatorMock(): MockObject
-    {
-        if (interface_exists(TranslatorInterface::class)) {
-            return $this->createMock(TranslatorInterface::class);
-        }
-
-        $translator = $this->createMock(LegacyTranslatorInterface::class);
-        $translator->method('getLocale')->willReturn('en');
-
-        return $translator;
-    }
-
-    private function getRequestStack(): RequestStack
-    {
-        $requestStack = new RequestStack();
-        $request = $this->createMock(Request::class);
-        $request
-            ->method('getLocale')
-            ->willReturn('en');
-        $requestStack->push($request);
-
-        return $requestStack;
     }
 }

--- a/tests/Type/DateTimePickerTypeTest.php
+++ b/tests/Type/DateTimePickerTypeTest.php
@@ -13,15 +13,12 @@ declare(strict_types=1);
 
 namespace Sonata\Form\Tests\Type;
 
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use Sonata\Form\Date\MomentFormatConverter;
 use Sonata\Form\Type\DateTimePickerType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\PreloadedExtension;
 use Symfony\Component\Form\Test\TypeTestCase;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Translation\TranslatorInterface as LegacyTranslatorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -29,12 +26,24 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class DateTimePickerTypeTest extends TypeTestCase
 {
+    /**
+     * @var Stub&TranslatorInterface
+     */
+    private $translator;
+
+    protected function setUp(): void
+    {
+        $this->translator = $this->createStub(TranslatorInterface::class);
+
+        parent::setUp();
+    }
+
     public function testParentIsDateTimeType(): void
     {
         $form = new DateTimePickerType(
             $this->createMock(MomentFormatConverter::class),
-            $this->getTranslatorMock(),
-            $this->getRequestStack()
+            $this->translator,
+            'en'
         );
 
         $this->assertSame(DateTimeType::class, $form->getParent());
@@ -44,8 +53,8 @@ class DateTimePickerTypeTest extends TypeTestCase
     {
         $type = new DateTimePickerType(
             new MomentFormatConverter(),
-            $this->getTranslatorMock(),
-            $this->getRequestStack()
+            $this->translator,
+            'en'
         );
 
         $this->assertSame('sonata_type_datetime_picker', $type->getBlockPrefix());
@@ -86,39 +95,12 @@ class DateTimePickerTypeTest extends TypeTestCase
     {
         $type = new DateTimePickerType(
             new MomentFormatConverter(),
-            $this->getTranslatorMock(),
-            $this->getRequestStack()
+            $this->translator,
+            'en'
         );
 
         return [
             new PreloadedExtension([$type], []),
         ];
-    }
-
-    /**
-     * @return MockObject|TranslatorInterface|LegacyTranslatorInterface\
-     */
-    private function getTranslatorMock(): MockObject
-    {
-        if (interface_exists(TranslatorInterface::class)) {
-            return $this->createMock(TranslatorInterface::class);
-        }
-
-        $translator = $this->createMock(LegacyTranslatorInterface::class);
-        $translator->method('getLocale')->willReturn('en');
-
-        return $translator;
-    }
-
-    private function getRequestStack(): RequestStack
-    {
-        $requestStack = new RequestStack();
-        $request = $this->createMock(Request::class);
-        $request
-            ->method('getLocale')
-            ->willReturn('en');
-        $requestStack->push($request);
-
-        return $requestStack;
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

`BasePickerType` needed a `RequestStack` object and it didn't work without a Request. 

With this change, `BasePickerType` receives a default locale (`kernel.default_locale` parameter) and when the request is made, the [LocalAwareListener](https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/HttpKernel/EventListener/LocaleAwareListener.php) (through `LocalAwareInterface` and `kernel.locale_aware` tag) set the locale from the Request.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/form-extensions/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #108.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/form-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated passing a `RequestStack` object to `BasePickerType` as third parameter, the default locale should be passed instead.
### Fixed
- Fixed using `BasePickerType` without a request.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
