### PR TITLE
Bump symfony to 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,10 @@ matrix:
     - php: '7.2'
       env: COMPOSER_FLAGS="--prefer-lowest"
     - php: '7.3'
+      env: SYMFONY=4.4.*
+    - php: '7.3'
+      env: SYMFONY=5.1.*
+    - php: '7.3'
       env: SYMFONY_DEPRECATIONS_HELPER=0
   allow_failures:
     - php: nightly

--- a/composer.json
+++ b/composer.json
@@ -24,13 +24,13 @@
         "jms/metadata": "^2.1",
         "jms/serializer": "^2.0 || ^3.0",
         "sonata-project/doctrine-extensions": "^1.1",
-        "symfony/event-dispatcher": "^4.4 || ^5.0",
-        "symfony/form": "^4.4 || ^5.0",
-        "symfony/options-resolver": "^4.4 || ^5.0",
-        "symfony/property-access": "^4.4 || ^5.0",
-        "symfony/security-csrf": "^4.4 || ^5.0",
-        "symfony/translation": "^4.4 || ^5.0",
-        "symfony/validator": "^4.4 || ^5.0",
+        "symfony/event-dispatcher": "^4.4 || ^5.1",
+        "symfony/form": "^4.4 || ^5.1",
+        "symfony/options-resolver": "^4.4 || ^5.1",
+        "symfony/property-access": "^4.4 || ^5.1",
+        "symfony/security-csrf": "^4.4 || ^5.1",
+        "symfony/translation": "^4.4 || ^5.1",
+        "symfony/validator": "^4.4 || ^5.1",
         "twig/twig": "^2.12 || ^3.0"
     },
     "conflict": {
@@ -40,13 +40,13 @@
         "doctrine/persistence": "^1.1",
         "matthiasnoback/symfony-config-test": "^4.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
-        "symfony/config": "^4.4 || ^5.0",
-        "symfony/dependency-injection": "^4.4 || ^5.0",
-        "symfony/framework-bundle": "^4.4 || ^5.0",
-        "symfony/http-foundation": "^4.4 || ^5.0",
-        "symfony/http-kernel": "^4.4 || ^5.0",
+        "symfony/config": "^4.4 || ^5.1",
+        "symfony/dependency-injection": "^4.4 || ^5.1",
+        "symfony/framework-bundle": "^4.4 || ^5.1",
+        "symfony/http-foundation": "^4.4 || ^5.1",
+        "symfony/http-kernel": "^4.4 || ^5.1",
         "symfony/phpunit-bridge": "^5.1",
-        "symfony/twig-bridge": "^4.4 || ^5.0"
+        "symfony/twig-bridge": "^4.4 || ^5.1"
     },
     "suggest": {
         "doctrine/persistence": "If you want to use BaseDoctrineORMSerializationType"


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Symfony 5.0 is unmaintained.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/form-extensions/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/form-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Bumped Symfony to 5.1
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
