### PR TITLE
Remove triggering deprecation when loading class

### DIFF
--- a/src/Bridge/Symfony/Resources/config/form_types.xml
+++ b/src/Bridge/Symfony/Resources/config/form_types.xml
@@ -41,6 +41,7 @@
             <argument type="service" id="translator"/>
         </service>
         <service id="sonata.form.type.equal" class="Sonata\Form\Type\EqualType">
+            <deprecated>The "%service_id%" service is deprecated since sonata-project/form-extensions 1.2 and will be removed in 2.0. Use Sonata\AdminBundle\Form\Type\Operator\EqualOperatorType instead</deprecated>
             <tag name="form.type" alias="sonata_type_equal"/>
             <argument type="service" id="translator"/>
         </service>

--- a/src/Type/EqualType.php
+++ b/src/Type/EqualType.php
@@ -17,12 +17,6 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\EqualType class is deprecated since version 1.2 and will be removed in 2.0.'
-    .' Use Sonata\AdminBundle\Form\Type\Operator\EqualOperatorType instead.',
-    E_USER_DEPRECATED
-);
-
 /**
  * NEXT_MAJOR: remove this class.
  *


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

When using this package, you always get:

```
The Sonata\Form\Type\EqualType class is deprecated since version 1.2 and will be removed in 2.0. Use Sonata\AdminBundle\Form\Type\Operator\EqualOperatorType instead.
```

even if you are not using the type, I removed the `trigger_error` call and added it to the service definition.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/form-extensions/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/form-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed triggering a deprecation for EqualType only when it is used. 
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
