### PR TITLE
Remove references to non-existing classes

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,6 +9,3 @@ parameters:
     excludes_analyse:
         - src/Test/AbstractWidgetTestCase.php
         - tests/bootstrap.php
-
-    ignoreErrors:
-        - '#Class Sonata\\Form\\Validator\\LegacyExecutionContextInterface not found.#'

--- a/src/Validator/ErrorElement.php
+++ b/src/Validator/ErrorElement.php
@@ -162,16 +162,12 @@ final class ErrorElement
 
         $subPath = (string) $this->getCurrentPropertyPath();
 
-        if ($this->context instanceof LegacyExecutionContextInterface) {
-            $this->context->addViolationAt($subPath, $message, $parameters, $value);
-        } else {
-            $this->context->buildViolation($message)
-               ->atPath($subPath)
-               ->setParameters($parameters)
-               ->setTranslationDomain($translationDomain)
-               ->setInvalidValue($value)
-               ->addViolation();
-        }
+        $this->context->buildViolation($message)
+           ->atPath($subPath)
+           ->setParameters($parameters)
+           ->setTranslationDomain($translationDomain)
+           ->setInvalidValue($value)
+           ->addViolation();
 
         $this->errors[] = [$message, $parameters, $value];
 

--- a/src/Validator/InlineValidator.php
+++ b/src/Validator/InlineValidator.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Sonata\Form\Validator;
 
+use Sonata\Form\Validator\Constraints\InlineConstraint;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\ConstraintValidatorFactoryInterface;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 final class InlineValidator extends ConstraintValidator
 {
@@ -40,6 +42,10 @@ final class InlineValidator extends ConstraintValidator
 
     public function validate($value, Constraint $constraint): void
     {
+        if (!$constraint instanceof InlineConstraint) {
+            throw new UnexpectedTypeException($constraint, InlineConstraint::class);
+        }
+
         if ($constraint->isClosure()) {
             $function = $constraint->getClosure();
         } else {

--- a/tests/Validator/ErrorElementTest.php
+++ b/tests/Validator/ErrorElementTest.php
@@ -19,7 +19,6 @@ use Sonata\Form\Validator\ErrorElement;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\ConstraintValidatorFactoryInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
-use Symfony\Component\Validator\ExecutionContextInterface as LegacyExecutionContextInterface;
 use Symfony\Component\Validator\Validator\ContextualValidatorInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
@@ -43,30 +42,28 @@ class ErrorElementTest extends TestCase
                 ->method('getPropertyPath')
                 ->willReturn('bar');
 
-        if ($this->context instanceof ExecutionContextInterface) {
-            $builder = $this->createMock(ConstraintViolationBuilderInterface::class);
-            $builder
-                ->method($this->anything())
-                ->willReturnSelf();
+        $builder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $builder
+            ->method($this->anything())
+            ->willReturnSelf();
 
-            $this->context
-                ->method('buildViolation')
-                ->willReturn($builder);
+        $this->context
+            ->method('buildViolation')
+            ->willReturn($builder);
 
-            $validator = $this->createMock(ValidatorInterface::class);
+        $validator = $this->createMock(ValidatorInterface::class);
 
-            $this->contextualValidator = $this->createMock(ContextualValidatorInterface::class);
-            $this->contextualValidator
-                ->method($this->anything())
-                ->willReturnSelf();
-            $validator
-                ->method('inContext')
-                ->willReturn($this->contextualValidator);
+        $this->contextualValidator = $this->createMock(ContextualValidatorInterface::class);
+        $this->contextualValidator
+            ->method($this->anything())
+            ->willReturnSelf();
+        $validator
+            ->method('inContext')
+            ->willReturn($this->contextualValidator);
 
-            $this->context
-                ->method('getValidator')
-                ->willReturn($validator);
-        }
+        $this->context
+            ->method('getValidator')
+            ->willReturn($validator);
 
         $this->subject = new Foo();
 
@@ -83,102 +80,63 @@ class ErrorElementTest extends TestCase
         $this->assertSame([], $this->errorElement->getErrors());
     }
 
-    /**
-     * @group legacy
-     */
     public function testGetErrors(): void
     {
         $this->errorElement->addViolation('Foo error message', ['bar_param' => 'bar_param_lvalue'], 'BAR');
         $this->assertSame([['Foo error message', ['bar_param' => 'bar_param_lvalue'], 'BAR']], $this->errorElement->getErrors());
     }
 
-    /**
-     * @group legacy
-     */
     public function testAddViolation(): void
     {
         $this->errorElement->addViolation(['Foo error message', ['bar_param' => 'bar_param_lvalue'], 'BAR']);
         $this->assertSame([['Foo error message', ['bar_param' => 'bar_param_lvalue'], 'BAR']], $this->errorElement->getErrors());
     }
 
-    /**
-     * @group legacy
-     */
     public function testAddViolationWithTranslationDomain(): void
     {
         $this->errorElement->addViolation(['Foo error message', ['bar_param' => 'bar_param_lvalue'], 'BAR'], [], null, 'translation_domain');
         $this->assertSame([['Foo error message', ['bar_param' => 'bar_param_lvalue'], 'BAR']], $this->errorElement->getErrors());
     }
 
-    /**
-     * @group legacy
-     */
     public function testAddConstraint(): void
     {
         $constraint = new NotNull();
-        if ($this->context instanceof LegacyExecutionContextInterface) {
-            $this->context->expects($this->once())
-                ->method('validateValue')
-                ->with($this->equalTo($this->subject), $this->equalTo($constraint), $this->equalTo(''), $this->equalTo('foo_core'))
-                ->willReturn(null);
-        } else {
-            $this->contextualValidator->expects($this->once())
-                ->method('atPath')
-                ->with('');
-            $this->contextualValidator->expects($this->once())
-                ->method('validate')
-                ->with($this->subject, $constraint, ['foo_core']);
-        }
+        $this->contextualValidator->expects($this->once())
+            ->method('atPath')
+            ->with('');
+        $this->contextualValidator->expects($this->once())
+            ->method('validate')
+            ->with($this->subject, $constraint, ['foo_core']);
 
         $this->errorElement->addConstraint($constraint);
     }
 
-    /**
-     * @group legacy
-     */
     public function testWith(): void
     {
         $constraint = new NotNull();
 
-        if ($this->context instanceof LegacyExecutionContextInterface) {
-            $this->context->expects($this->once())
-                ->method('validateValue')
-                ->with($this->equalTo(null), $this->equalTo($constraint), $this->equalTo('bar'), $this->equalTo('foo_core'))
-                ->willReturn(null);
-        } else {
-            $this->contextualValidator->expects($this->once())
-                ->method('atPath')
-                ->with('bar');
-            $this->contextualValidator->expects($this->once())
-                ->method('validate')
-                ->with(null, $constraint, ['foo_core']);
-        }
+        $this->contextualValidator->expects($this->once())
+            ->method('atPath')
+            ->with('bar');
+        $this->contextualValidator->expects($this->once())
+            ->method('validate')
+            ->with(null, $constraint, ['foo_core']);
 
         $this->errorElement->with('bar');
         $this->errorElement->addConstraint($constraint);
         $this->errorElement->end();
     }
 
-    /**
-     * @group legacy
-     */
     public function testCall(): void
     {
         $constraint = new NotNull();
 
-        if ($this->context instanceof LegacyExecutionContextInterface) {
-            $this->context->expects($this->once())
-                ->method('validateValue')
-                ->with($this->equalTo(null), $this->equalTo($constraint), $this->equalTo('bar'), $this->equalTo('foo_core'))
-                ->willReturn(null);
-        } else {
-            $this->contextualValidator->expects($this->once())
-                ->method('atPath')
-                ->with('bar');
-            $this->contextualValidator->expects($this->once())
-                ->method('validate')
-                ->with(null, $constraint, ['foo_core']);
-        }
+        $this->contextualValidator->expects($this->once())
+            ->method('atPath')
+            ->with('bar');
+        $this->contextualValidator->expects($this->once())
+            ->method('validate')
+            ->with(null, $constraint, ['foo_core']);
 
         $this->errorElement->with('bar');
         $this->errorElement->assertNotNull();
@@ -203,26 +161,16 @@ class ErrorElementTest extends TestCase
         $this->assertSame('bar', $this->errorElement->getFullPropertyPath());
     }
 
-    /**
-     * @group legacy
-     */
     public function testFluidInterface(): void
     {
         $constraint = new NotNull();
 
-        if ($this->context instanceof LegacyExecutionContextInterface) {
-            $this->context
-                ->method('validateValue')
-                ->with($this->equalTo($this->subject), $this->equalTo($constraint), $this->equalTo(''), $this->equalTo('foo_core'))
-                ->willReturn(null);
-        } else {
-            $this->contextualValidator
-                ->method('atPath')
-                ->with('');
-            $this->contextualValidator
-                ->method('validate')
-                ->with($this->subject, $constraint, ['foo_core']);
-        }
+        $this->contextualValidator
+            ->method('atPath')
+            ->with('');
+        $this->contextualValidator
+            ->method('validate')
+            ->with($this->subject, $constraint, ['foo_core']);
 
         $this->assertSame($this->errorElement, $this->errorElement->with('baz'));
         $this->assertSame($this->errorElement, $this->errorElement->end());


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

[`Symfony\Component\Validator\ExecutionContextInterface` was deprecated in 2.5](https://github.com/symfony/symfony/blob/3.0/src/Symfony/Component/Validator/CHANGELOG.md#250) and removed in 3.0.

I've remove some `@group` annotations, I think [they were added](https://github.com/sonata-project/SonataCoreBundle/pull/459) when there were some deprecations.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/form-extensions/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
