### PR TITLE
Deprecate BaseDoctrineORMSerializationType

### DIFF
--- a/UPGRADE-1.x.md
+++ b/UPGRADE-1.x.md
@@ -1,9 +1,19 @@
 UPGRADE 1.x
 ===========
 
+## Deprecated `Sonata\Form\Type\BaseDoctrineORMSerializationType`.
+
+This class has been deprecated without replacement.
+
+UPGRADE FROM 1.2 to 1.6
+=======================
+
 ## Sonata\Form\Type\BasePickerType
 
 Deprecate passing a `RequestStack` object as third parameter, you MUST pass a default locale instead.
+
+UPGRADE FROM 1.0 to 1.2
+=======================
 
 ## Deprecated EqualType form
 

--- a/src/Type/BaseDoctrineORMSerializationType.php
+++ b/src/Type/BaseDoctrineORMSerializationType.php
@@ -26,6 +26,10 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * This is a doctrine serialization form type that generates a form type from class serialization metadata
  * and doctrine metadata.
  *
+ * NEXT_MAJOR: Remove this class.
+ *
+ * @deprecated since sonata-project/form-extensions 1.x, to be removed with 2.0.
+ *
  * @author Vincent Composieux <vincent.composieux@gmail.com>
  */
 class BaseDoctrineORMSerializationType extends AbstractType


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I bumped into this class, apparently it was used [with DoctrineORMSerializationType](https://github.com/sonata-project/SonataCoreBundle/blob/2.x/Form/Type/DoctrineORMSerializationType.php#L17), but that class was removed in 3.0. I did a quick search I couldn't find any usage:
No usage in [form-extensions](https://github.com/sonata-project/form-extensions/search?q=BaseDoctrineORMSerializationType&unscoped_q=BaseDoctrineORMSerializationType), [sonata-doctrine-extensions](https://github.com/sonata-project/sonata-doctrine-extensions/search?q=BaseDoctrineORMSerializationType&unscoped_q=BaseDoctrineORMSerializationType), [SonataDoctrineORMAdminBundle](https://github.com/sonata-project/SonataDoctrineORMAdminBundle/search?q=BaseDoctrineORMSerializationType&unscoped_q=BaseDoctrineORMSerializationType) neither [SonataAdminBundle](https://github.com/sonata-project/SonataAdminBundle/search?q=BaseDoctrineORMSerializationType&unscoped_q=BaseDoctrineORMSerializationType).


<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/form-extensions/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/form-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated `Sonata\Form\Type\BaseDoctrineORMSerializationType`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
