### PR TITLE
Revert deprecation of BaseDoctrineORMSerializationType

### DIFF
--- a/UPGRADE-1.x.md
+++ b/UPGRADE-1.x.md
@@ -1,19 +1,9 @@
 UPGRADE 1.x
 ===========
 
-## Deprecated `Sonata\Form\Type\BaseDoctrineORMSerializationType`.
-
-This class has been deprecated without replacement.
-
-UPGRADE FROM 1.2 to 1.6
-=======================
-
 ## Sonata\Form\Type\BasePickerType
 
 Deprecate passing a `RequestStack` object as third parameter, you MUST pass a default locale instead.
-
-UPGRADE FROM 1.0 to 1.2
-=======================
 
 ## Deprecated EqualType form
 

--- a/UPGRADE-1.x.md
+++ b/UPGRADE-1.x.md
@@ -1,9 +1,15 @@
 UPGRADE 1.x
 ===========
 
+UPGRADE FROM 1.2 to 1.6
+=======================
+
 ## Sonata\Form\Type\BasePickerType
 
 Deprecate passing a `RequestStack` object as third parameter, you MUST pass a default locale instead.
+
+UPGRADE FROM 1.0 to 1.2
+=======================
 
 ## Deprecated EqualType form
 

--- a/src/Type/BaseDoctrineORMSerializationType.php
+++ b/src/Type/BaseDoctrineORMSerializationType.php
@@ -26,10 +26,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * This is a doctrine serialization form type that generates a form type from class serialization metadata
  * and doctrine metadata.
  *
- * NEXT_MAJOR: Remove this class.
- *
- * @deprecated since sonata-project/form-extensions 1.x, to be removed with 2.0.
- *
  * @author Vincent Composieux <vincent.composieux@gmail.com>
  */
 class BaseDoctrineORMSerializationType extends AbstractType


### PR DESCRIPTION
@wbloszyk [pointed out](https://github.com/sonata-project/form-extensions/pull/131#issuecomment-687016868), that the class is being used in some packages, TIL that you can search in the organization:

https://github.com/search?q=org%3Asonata-project+BaseDoctrineORMSerializationType&type=Code 🤦‍♂️ 

Since there has been no release, I guess there is no need of changelog and once is merged, we should remove the changelog of https://github.com/sonata-project/form-extensions/pull/131.