### PR TITLE
Allow instances of `\DateTimeImmutable` in `BasePickerType`

### DIFF
--- a/UPGRADE-1.x.md
+++ b/UPGRADE-1.x.md
@@ -1,6 +1,13 @@
 UPGRADE 1.x
 ===========
 
+UPGRADE FROM 1.x to 1.x
+=======================
+
+## Sonata\Form\Type\BasePickerType
+
+Added support for instances of `\DateTimeImmutable` in form options "dp_min_date" and "dp_max_date".
+
 UPGRADE FROM 1.2 to 1.6
 =======================
 

--- a/src/Type/BasePickerType.php
+++ b/src/Type/BasePickerType.php
@@ -117,10 +117,10 @@ abstract class BasePickerType extends AbstractType implements LocaleAwareInterfa
         // use seconds if it's allowed in format
         $options['dp_use_seconds'] = false !== strpos($format, 's');
 
-        if ($options['dp_min_date'] instanceof \DateTime) {
+        if ($options['dp_min_date'] instanceof \DateTimeInterface) {
             $options['dp_min_date'] = $this->formatObject($options['dp_min_date'], $format);
         }
-        if ($options['dp_max_date'] instanceof \DateTime) {
+        if ($options['dp_max_date'] instanceof \DateTimeInterface) {
             $options['dp_max_date'] = $this->formatObject($options['dp_max_date'], $format);
         }
 
@@ -133,7 +133,7 @@ abstract class BasePickerType extends AbstractType implements LocaleAwareInterfa
             if (false !== strpos($key, 'dp_')) {
                 // We remove 'dp_' and camelize the options names
                 $dpKey = substr($key, 3);
-                $dpKey = preg_replace_callback('/_([a-z])/', static function ($c) {
+                $dpKey = preg_replace_callback('/_([a-z])/', static function (array $c): string {
                     return strtoupper($c[1]);
                 }, $dpKey);
 
@@ -141,7 +141,7 @@ abstract class BasePickerType extends AbstractType implements LocaleAwareInterfa
             }
         }
 
-        $view->vars['datepicker_use_button'] = empty($options['datepicker_use_button']) ? false : true;
+        $view->vars['datepicker_use_button'] = !empty($options['datepicker_use_button']);
         $view->vars['dp_options'] = $dpOptions;
     }
 
@@ -198,7 +198,7 @@ abstract class BasePickerType extends AbstractType implements LocaleAwareInterfa
         return $request->getLocale();
     }
 
-    private function formatObject(\DateTime $dateTime, $format): string
+    private function formatObject(\DateTimeInterface $dateTime, $format): string
     {
         $formatter = new \IntlDateFormatter($this->locale, \IntlDateFormatter::NONE, \IntlDateFormatter::NONE);
         $formatter->setPattern($format);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Allow instances of `\DateTimeImmutable` in `BasePickerType`.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/form-extensions/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/form-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Support for instances of `\DateTimeImmutable` in form options "dp_min_date" and "dp_max_date" at `BasePickerType`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
