### PR TITLE
make compat with sf5.0 form and parameter type declarations in conjun…

### DIFF
--- a/src/EventListener/ResizeFormListener.php
+++ b/src/EventListener/ResizeFormListener.php
@@ -94,7 +94,7 @@ final class ResizeFormListener implements EventSubscriberInterface
 
         // First remove all rows except for the prototype row
         foreach ($form as $name => $child) {
-            $form->remove($name);
+            $form->remove((string)$name);
         }
 
         // Then add all rows again in the correct order
@@ -135,7 +135,7 @@ final class ResizeFormListener implements EventSubscriberInterface
 
         // Add all additional rows
         foreach ($data as $name => $value) {
-            if (!$form->has($name)) {
+            if (!$form->has((string)$name)) {
                 $buildOptions = [
                     'property_path' => '['.$name.']',
                 ];
@@ -176,7 +176,7 @@ final class ResizeFormListener implements EventSubscriberInterface
         }
 
         foreach ($data as $name => $child) {
-            if (!$form->has($name)) {
+            if (!$form->has((string)$name)) {
                 unset($data[$name]);
             }
         }

--- a/src/EventListener/ResizeFormListener.php
+++ b/src/EventListener/ResizeFormListener.php
@@ -135,7 +135,7 @@ final class ResizeFormListener implements EventSubscriberInterface
 
         // Add all additional rows
         foreach ($data as $name => $value) {
-            if (!$form->has((string)$name)) {
+            if (!$form->has((string) $name)) {
                 $buildOptions = [
                     'property_path' => '['.$name.']',
                 ];

--- a/src/EventListener/ResizeFormListener.php
+++ b/src/EventListener/ResizeFormListener.php
@@ -94,7 +94,7 @@ final class ResizeFormListener implements EventSubscriberInterface
 
         // First remove all rows except for the prototype row
         foreach ($form as $name => $child) {
-            $form->remove((string)$name);
+            $form->remove((string) $name);
         }
 
         // Then add all rows again in the correct order

--- a/src/EventListener/ResizeFormListener.php
+++ b/src/EventListener/ResizeFormListener.php
@@ -176,7 +176,7 @@ final class ResizeFormListener implements EventSubscriberInterface
         }
 
         foreach ($data as $name => $child) {
-            if (!$form->has((string)$name)) {
+            if (!$form->has((string) $name)) {
                 unset($data[$name]);
             }
         }

--- a/src/EventListener/ResizeFormListener.php
+++ b/src/EventListener/ResizeFormListener.php
@@ -130,7 +130,7 @@ final class ResizeFormListener implements EventSubscriberInterface
 
         // Remove all empty rows except for the prototype row
         foreach ($form as $name => $child) {
-            $form->remove($name);
+            $form->remove((string)$name);
         }
 
         // Add all additional rows

--- a/src/EventListener/ResizeFormListener.php
+++ b/src/EventListener/ResizeFormListener.php
@@ -130,7 +130,7 @@ final class ResizeFormListener implements EventSubscriberInterface
 
         // Remove all empty rows except for the prototype row
         foreach ($form as $name => $child) {
-            $form->remove((string)$name);
+            $form->remove((string) $name);
         }
 
         // Add all additional rows


### PR DESCRIPTION
## make compat with sf5.0 form and parameter type declarations in conjunction with the CollectionType

When using the Collection Type we get numbers (indice of the form collection) as keys, since they are int's
the symfony5.0 type declaration throws an exception since it requires a string.

Casting to string before all calls fixes this

I am targeting this branch, because it would make next version compatible with symfony5.0 as well.

## Changelog

```markdown
### Changed
- Cast form name to string for symfony5.0 compatibility
```
