### PR TITLE
Allow PHP8

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,6 +27,7 @@ jobs:
                 php-version:
                     - '7.3'
                     - '7.4'
+                    - '8.0'
                 dependencies: [highest]
                 allowed-to-fail: [false]
                 variant: [normal]
@@ -34,10 +35,6 @@ jobs:
                     - php-version: '7.3'
                       dependencies: lowest
                       allowed-to-fail: false
-                      variant: normal
-                    - php-version: '8.0'
-                      dependencies: highest
-                      allowed-to-fail: true
                       variant: normal
                     - php-version: '7.4'
                       dependencies: highest
@@ -61,10 +58,6 @@ jobs:
 
             - name: Add PHPUnit matcher
               run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
-
-            - name: Configuration required for PHP 8.0
-              if: matrix.php-version == '8.0'
-              run: composer config platform.php 7.4.99
 
             - name: Install variant
               if: matrix.variant != 'normal'

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": ">=7.3",
         "jms/metadata": "^2.1",
         "jms/serializer": "^2.0 || ^3.0",
         "sonata-project/doctrine-extensions": "^1.10.1",


### PR DESCRIPTION
Then we can merge https://github.com/sonata-project/dev-kit/pull/1338

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/twig-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Support for PHP8
```