### PR TITLE
Fix deprecations and up Symfony versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,13 +24,13 @@
         "jms/metadata": "^2.1",
         "jms/serializer": "^2.0 || ^3.0",
         "sonata-project/doctrine-extensions": "^1.10.1",
-        "symfony/event-dispatcher": "^4.4 || ^5.1",
-        "symfony/form": "^4.4 || ^5.1",
-        "symfony/options-resolver": "^4.4 || ^5.1",
-        "symfony/property-access": "^4.4 || ^5.1",
-        "symfony/security-csrf": "^4.4 || ^5.1",
-        "symfony/translation": "^4.4 || ^5.1",
-        "symfony/validator": "^4.4 || ^5.1",
+        "symfony/event-dispatcher": "^4.4 || ^5.3",
+        "symfony/form": "^4.4 || ^5.3",
+        "symfony/options-resolver": "^4.4 || ^5.3",
+        "symfony/property-access": "^4.4 || ^5.3",
+        "symfony/security-csrf": "^4.4 || ^5.3",
+        "symfony/translation": "^4.4 || ^5.3",
+        "symfony/validator": "^4.4 || ^5.3",
         "twig/twig": "^2.12 || ^3.0"
     },
     "conflict": {
@@ -41,13 +41,13 @@
         "doctrine/persistence": "^1.3 || ^2.0",
         "matthiasnoback/symfony-config-test": "^4.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
-        "symfony/config": "^4.4 || ^5.1",
-        "symfony/dependency-injection": "^4.4 || ^5.1",
-        "symfony/framework-bundle": "^4.4 || ^5.1",
-        "symfony/http-foundation": "^4.4 || ^5.1",
-        "symfony/http-kernel": "^4.4 || ^5.1",
-        "symfony/phpunit-bridge": "^5.1.8",
-        "symfony/twig-bridge": "^4.4 || ^5.1"
+        "symfony/config": "^4.4 || ^5.3",
+        "symfony/dependency-injection": "^4.4 || ^5.3",
+        "symfony/framework-bundle": "^4.4 || ^5.3",
+        "symfony/http-foundation": "^4.4 || ^5.3",
+        "symfony/http-kernel": "^4.4 || ^5.3",
+        "symfony/phpunit-bridge": "^5.3",
+        "symfony/twig-bridge": "^4.4 || ^5.3"
     },
     "suggest": {
         "doctrine/persistence": "If you want to use BaseDoctrineORMSerializationType"

--- a/src/Fixtures/StubTranslator.php
+++ b/src/Fixtures/StubTranslator.php
@@ -21,4 +21,9 @@ final class StubTranslator implements TranslatorInterface
     {
         return '[trans]'.strtr($id, $parameters).'[/trans]';
     }
+
+    public function getLocale(): string
+    {
+        return 'en';
+    }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/form-extensions/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/form-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Removed Support for Symfony 5.1 and 5.2
### Fixed
- Fixed deprecation on `StubTranslation` by adding `getLocale()` method
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
