### PR TITLE
Fix `ResizeFormListener::preSubmit` using integer keys

### DIFF
--- a/src/EventListener/ResizeFormListener.php
+++ b/src/EventListener/ResizeFormListener.php
@@ -149,6 +149,8 @@ final class ResizeFormListener implements EventSubscriberInterface
 
                 $options = array_merge($this->typeOptions, $buildOptions);
 
+                $name = \is_int($name) ? (string) $name : $name;
+
                 $form->add($name, $this->type, $options);
             }
 

--- a/tests/EventListener/ResizeFormListenerTest.php
+++ b/tests/EventListener/ResizeFormListenerTest.php
@@ -74,6 +74,30 @@ final class ResizeFormListenerTest extends TestCase
         $listener->preSetData($event);
     }
 
+    public function testPreSubmitWithArrayData(): void
+    {
+        $listener = new ResizeFormListener('form', [], true, null);
+
+        $form = $this->createMock(Form::class);
+        $form
+            ->method('getIterator')
+            ->willReturn(new \ArrayIterator());
+        $form
+            ->method('has')
+            ->willReturn(false);
+        $form
+            ->expects(static::exactly(2))
+            ->method('add')
+            ->withConsecutive(
+                ['0'],
+                ['1'],
+            );
+
+        $event = new FormEvent($form, ['foo', 'bar']);
+
+        $listener->preSubmit($event);
+    }
+
     public function testPreSetDataThrowsExceptionWithStringEventData(): void
     {
         $listener = new ResizeFormListener('form', [], false, null);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Follow up of https://github.com/sonata-project/form-extensions/pull/290, I missed casting to string in another place.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - 2.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/form-extensions/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/form-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Submitting `CollectionType` in Symfony 6
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
