### PR TITLE
Deprecate JMS related code

### DIFF
--- a/src/Bridge/Symfony/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/DependencyInjection/Configuration.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\Form\Bridge\Symfony\DependencyInjection;
 
+use Symfony\Component\Config\Definition\BaseNode;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -31,6 +32,7 @@ class Configuration implements ConfigurationInterface
         $rootNode = $treeBuilder->getRootNode();
 
         $this->addFlashMessageSection($rootNode);
+        // NEXT_MAJOR: Remove this line and the jms/serializer and jms/metadata dependency.
         $this->addSerializerFormats($rootNode);
 
         return $treeBuilder;
@@ -62,6 +64,8 @@ class Configuration implements ConfigurationInterface
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * Adds configuration for serializer formats.
      *
      * @psalm-suppress PossiblyNullReference, PossiblyUndefinedMethod
@@ -73,6 +77,12 @@ class Configuration implements ConfigurationInterface
         $node
             ->children()
                 ->arrayNode('serializer')
+                    ->setDeprecated(
+                        ...$this->forConfig(
+                            'The "%node%" option is deprecated since sonata-project/form-extensions 1.x.',
+                            '1.x'
+                        )
+                    )
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->arrayNode('formats')
@@ -83,5 +93,24 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
             ->end();
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @return string[]
+     */
+    private function forConfig(string $message, string $version): array
+    {
+        // @phpstan-ignore-next-line
+        if (method_exists(BaseNode::class, 'getDeprecation')) {
+            return [
+                'sonata-project/form-extension',
+                $version,
+                $message,
+            ];
+        }
+
+        return [$message];
     }
 }

--- a/src/Bridge/Symfony/DependencyInjection/SonataFormExtension.php
+++ b/src/Bridge/Symfony/DependencyInjection/SonataFormExtension.php
@@ -54,10 +54,13 @@ final class SonataFormExtension extends Extension implements PrependExtensionInt
 
         $container->setParameter('sonata.form.form_type', $config['form_type']);
 
+        // NEXT_MAJOR: Remove this call.
         $this->configureSerializerFormats($config);
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * @param mixed[] $config
      */
     private function configureSerializerFormats(array $config): void

--- a/src/Serializer/BaseSerializerHandler.php
+++ b/src/Serializer/BaseSerializerHandler.php
@@ -21,6 +21,10 @@ use JMS\Serializer\VisitorInterface;
 use Sonata\Doctrine\Model\ManagerInterface;
 
 /**
+ * NEXT_MAJOR: Remove this class.
+ *
+ * @deprecated since sonata-project/form-extensions version 1.x and will be removed in 2.0.
+ *
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
  */
 abstract class BaseSerializerHandler implements SerializerHandlerInterface

--- a/src/Serializer/SerializerHandlerInterface.php
+++ b/src/Serializer/SerializerHandlerInterface.php
@@ -16,6 +16,10 @@ namespace Sonata\Form\Serializer;
 use JMS\Serializer\Handler\SubscribingHandlerInterface;
 
 /**
+ * NEXT_MAJOR: Remove this interface.
+ *
+ * @deprecated since sonata-project/form-extensions version 1.x and will be removed in 2.0.
+ *
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
  */
 interface SerializerHandlerInterface extends SubscribingHandlerInterface

--- a/src/Type/BaseDoctrineORMSerializationType.php
+++ b/src/Type/BaseDoctrineORMSerializationType.php
@@ -25,6 +25,10 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
+ * NEXT_MAJOR: Remove this class.
+ *
+ * @deprecated since sonata-project/form-extensions version 1.x and will be removed in 2.0.
+ *
  * This is a doctrine serialization form type that generates a form type from class serialization metadata
  * and doctrine metadata.
  *


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - 2.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/form-extensions/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #275.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/form-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Sonata\Form\Serializer\BaseSerializerHandler
- Sonata\Form\Serializer\SerializerHandlerInterface
- Sonata\Form\Type\BaseDoctrineORMSerializationType
- serializer config key
```