### PR TITLE
fix init groups attribute in __sleep method for InlineConstraint class

### DIFF
--- a/src/Validator/Constraints/InlineConstraint.php
+++ b/src/Validator/Constraints/InlineConstraint.php
@@ -51,6 +51,9 @@ final class InlineConstraint extends Constraint
 
     public function __sleep(): array
     {
+        // @phpstan-ignore-next-line to initialize "groups" option if it is not set
+        $this->groups;
+
         if (!\is_string($this->service) || !\is_string($this->method)) {
             return [];
         }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Call ` $this->groups;` method in InlineConstraint class to initialize `parent::$groups`


<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - 2.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/form-extensions/blob/1.x/CONTRIBUTING.md#base-branch
-->
I encountered a bug when using the `InlineConstraint`with annotation style. I thought that the problem was from Symfony ^4.4.34 (the problem does not appear on Symfony 4.4.33). I opened [this issue](https://github.com/symfony/symfony/issues/45042). It was found that the problem that I encountered came from that there is no call to the` parent::__sleep()` method.

NB: in that issue, you will find all details to reproduce the bug.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #{put_issue_number_here}.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/form-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed `InlineConstraint` usage annotation due do unitialized constraint groups.
```
