### PR TITLE
Restore PHP 7.3 compatibility

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,6 +27,7 @@ jobs:
         strategy:
             matrix:
                 php-version:
+                    - '7.3'
                     - '7.4'
                     - '8.0'
                     - '8.1'
@@ -35,6 +36,10 @@ jobs:
                 symfony-require: ['']
                 variant: [normal]
                 include:
+                    - php-version: '7.3'
+                      dependencies: lowest
+                      allowed-to-fail: false
+                      variant: normal
                     - php-version: '7.4'
                       dependencies: lowest
                       allowed-to-fail: false

--- a/src/Twig/CanonicalizeRuntime.php
+++ b/src/Twig/CanonicalizeRuntime.php
@@ -26,7 +26,10 @@ final class CanonicalizeRuntime implements RuntimeExtensionInterface
         'fr' => ['fr', 'fr-ca', 'fr-ch'],
     ];
 
-    private RequestStack $requestStack;
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
 
     /**
      * @internal This class should only be used through Twig

--- a/tests/Twig/CanonicalizeRuntimeTest.php
+++ b/tests/Twig/CanonicalizeRuntimeTest.php
@@ -20,9 +20,15 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 final class CanonicalizeRuntimeTest extends TestCase
 {
-    private Request $request;
+    /**
+     * @var Request
+     */
+    private $request;
 
-    private CanonicalizeRuntime $canonicalizeRuntime;
+    /**
+     * @var CanonicalizeRuntime
+     */
+    private $canonicalizeRuntime;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - 2.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/form-extensions/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/form-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix compatibility with PHP 7.3.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
