### PR TITLE
Deprecate passing array to addViolation

### DIFF
--- a/UPGRADE-1.x.md
+++ b/UPGRADE-1.x.md
@@ -1,6 +1,22 @@
 UPGRADE 1.x
 ===========
 
+UPGRADE FROM 1.16 to 1.17
+=========================
+
+## Sonata\Form\Validator\ErrorElement
+
+Deprecate passing an array as first parameter of `addViolation`
+```php
+$errorElement->addViolation(['Foo error message', ['bar_param' => 'bar_param_lvalue'], 'BAR']);
+```
+
+You MUST call
+```php
+$errorElement->addViolation('Foo error message', ['bar_param' => 'bar_param_lvalue'], 'BAR');
+```
+instead.
+
 UPGRADE FROM 1.6 to 1.7
 =======================
 

--- a/src/Validator/ErrorElement.php
+++ b/src/Validator/ErrorElement.php
@@ -201,7 +201,14 @@ final class ErrorElement
      */
     public function addViolation($message, array $parameters = [], $value = null, string $translationDomain = self::DEFAULT_TRANSLATION_DOMAIN): self
     {
+        // NEXT_MAJOR: Remove this code and restrict param to string.
         if (\is_array($message)) {
+            @trigger_error(sprintf(
+                'Passing an array as argument 1 to "%s()" is deprecated'
+                .' since sonata-project/form-extensions 1.6 and will throw an error in 2.0.',
+                __METHOD__
+            ), \E_USER_DEPRECATED);
+
             $value = $message[2] ?? $value;
             // @phpstan-ignore-next-line see https://github.com/sonata-project/form-extensions/issues/358
             $parameters = isset($message[1]) ? (array) $message[1] : [];

--- a/tests/Validator/ErrorElementTest.php
+++ b/tests/Validator/ErrorElementTest.php
@@ -96,12 +96,22 @@ final class ErrorElementTest extends TestCase
         static::assertSame([['Foo error message', ['bar_param' => 'bar_param_lvalue'], 'BAR']], $this->errorElement->getErrors());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testAddViolation(): void
     {
         $this->errorElement->addViolation(['Foo error message', ['bar_param' => 'bar_param_lvalue'], 'BAR']);
         static::assertSame([['Foo error message', ['bar_param' => 'bar_param_lvalue'], 'BAR']], $this->errorElement->getErrors());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testAddViolationWithTranslationDomain(): void
     {
         $this->errorElement->addViolation(['Foo error message', ['bar_param' => 'bar_param_lvalue'], 'BAR'], [], null, 'translation_domain');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - 2.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/form-extensions/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because {reason}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #358.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/form-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Passing an array as first element of `ErrorElement::addViolation()`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
