### PR TITLE
Revert type casting because Symfony forms can return integer keys

### DIFF
--- a/src/EventListener/ResizeFormListener.php
+++ b/src/EventListener/ResizeFormListener.php
@@ -88,8 +88,9 @@ final class ResizeFormListener implements EventSubscriberInterface
         }
 
         // First remove all rows except for the prototype row
+        // Type cast to string, because Symfony form can returns integer keys
         foreach ($form as $name => $child) {
-            $form->remove($name);
+            $form->remove((string) $name);
         }
 
         // Then add all rows again in the correct order
@@ -126,12 +127,14 @@ final class ResizeFormListener implements EventSubscriberInterface
         }
 
         // Remove all empty rows except for the prototype row
+        // Type cast to string, because Symfony form can returns integer keys
         foreach ($form as $name => $child) {
-            $form->remove($name);
+            $form->remove((string) $name);
         }
 
         // Add all additional rows
         foreach ($data as $name => $value) {
+            // Type cast to string, because Symfony form can returns integer keys
             if (!$form->has((string) $name)) {
                 $buildOptions = [
                     'property_path' => '['.$name.']',
@@ -178,6 +181,7 @@ final class ResizeFormListener implements EventSubscriberInterface
         }
 
         foreach ($data as $name => $child) {
+            // Type cast to string, because Symfony form can returns integer keys
             if (!$form->has((string) $name)) {
                 unset($data[$name]);
             }

--- a/src/EventListener/ResizeFormListener.php
+++ b/src/EventListener/ResizeFormListener.php
@@ -90,6 +90,7 @@ final class ResizeFormListener implements EventSubscriberInterface
         // First remove all rows except for the prototype row
         // Type cast to string, because Symfony form can returns integer keys
         foreach ($form as $name => $child) {
+            // @phpstan-ignore-next-line
             $form->remove((string) $name);
         }
 
@@ -129,6 +130,7 @@ final class ResizeFormListener implements EventSubscriberInterface
         // Remove all empty rows except for the prototype row
         // Type cast to string, because Symfony form can returns integer keys
         foreach ($form as $name => $child) {
+            // @phpstan-ignore-next-line
             $form->remove((string) $name);
         }
 

--- a/tests/EventListener/ResizeFormListenerTest.php
+++ b/tests/EventListener/ResizeFormListenerTest.php
@@ -190,23 +190,37 @@ final class ResizeFormListenerTest extends TestCase
 
         $listener = new ResizeFormListener('form', $typeOptions, true, null);
 
-        $options = [
+        $options1 = [
             'property_path' => '[baz]',
+            'default' => 'option',
+        ];
+
+        $options2 = [
+            'property_path' => '[0]',
             'default' => 'option',
         ];
 
         $form = $this->createMock(Form::class);
         $form->expects(static::once())
             ->method('getIterator')
-            ->willReturn(new \ArrayIterator(['foo' => 'bar']));
-        $form->expects(static::once())
+            ->willReturn(new \ArrayIterator([
+                'foo' => 'bar',
+                0 => 'daz',
+            ]));
+        $form->expects(static::exactly(2))
             ->method('remove')
-            ->with('foo');
-        $form->expects(static::once())
+            ->withConsecutive(
+                ['foo'],
+                [0]
+            );
+        $form->expects(static::exactly(2))
             ->method('add')
-            ->with('baz', 'form', $options);
+            ->withConsecutive(
+                ['baz', 'form', $options1],
+                [0, 'form', $options2]
+            );
 
-        $data = ['baz' => 'caz'];
+        $data = ['baz' => 'caz', 0 => 'daz'];
 
         $event = new FormEvent($form, $data);
 
@@ -295,23 +309,26 @@ final class ResizeFormListenerTest extends TestCase
 
         $form = $this->createMock(Form::class);
         $form
-            ->expects(static::exactly(3))
+            ->expects(static::exactly(4))
             ->method('has')
             ->withConsecutive(
                 ['foo'],
                 ['bar'],
-                ['baz']
+                ['baz'],
+                [0]
             )
             ->willReturnOnConsecutiveCalls(
                 false,
                 false,
-                true
+                true,
+                false,
             );
 
         $data = [
             'foo' => 'foo-value',
             'bar' => 'bar-value',
             'baz' => 'baz-value',
+            0 => '0-value',
         ];
 
         $removedData = [


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - 2.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/form-extensions/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #368.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/form-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Added the type casting to string, because Symfony forms can return integer keys.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
