### PR TITLE
Handle moment locale when request locale has equal language and country parts

### DIFF
--- a/src/Twig/CanonicalizeRuntime.php
+++ b/src/Twig/CanonicalizeRuntime.php
@@ -52,6 +52,14 @@ final class CanonicalizeRuntime implements RuntimeExtensionInterface
             }
         }
 
+        // Handle locales that has equal langage part and country part.
+        if (str_contains($locale, '-')) {
+            $localeParts = explode('-', strtolower($locale));
+            if ($localeParts[0] === $localeParts[1]) {
+                $locale = $localeParts[0];
+            }
+        }
+
         return $locale;
     }
 

--- a/tests/Twig/CanonicalizeRuntimeTest.php
+++ b/tests/Twig/CanonicalizeRuntimeTest.php
@@ -103,6 +103,7 @@ final class CanonicalizeRuntimeTest extends TestCase
             ['id', 'id'],
             ['is', 'is'],
             ['it', 'it'],
+            ['it', 'it-IT'],
             ['ja', 'ja'],
             ['jv', 'jv'],
             ['ka', 'ka'],


### PR DESCRIPTION


<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Handle moment locale

This PR aims to retrieve expected moment locale when request's locale includes country part like 'it-IT' or 'pl-PL'.
When this kind of locales are used in Request, sonata try to load a moment locale file that does not exists (ie: /bundles/sonataform/moment-locale/it-IT.js)

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - 2.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/form-extensions/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a bug fix.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/form-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Fixed
- Date pickers now select the correct locale when language and country parts are the same, eg: `it-IT`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [x] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
