### PR TITLE
Fix btn_add definitions and deprecate btn_catalogue

### DIFF
--- a/docs/reference/form_types.rst
+++ b/docs/reference/form_types.rst
@@ -145,7 +145,7 @@ to the underlying forms::
 
 The available options (which can be passed as a third parameter to ``FormMapper::add()``) are:
 
-btn_add and btn_catalogue:
+btn_add and btn_translation_domain:
   The label on the ``add`` button can be customized
   with this parameters. Setting it to ``false`` will hide the
   corresponding button. You can also specify a custom translation catalogue

--- a/src/Type/CollectionType.php
+++ b/src/Type/CollectionType.php
@@ -19,6 +19,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -39,6 +40,12 @@ final class CollectionType extends AbstractType
     public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['btn_add'] = $options['btn_add'];
+
+        // NEXT_MAJOR: Remove the btn_catalogue usage.
+        $view->vars['btn_translation_domain'] =
+            'SonataFormBundle' !== $options['btn_translation_domain']
+                ? $options['btn_translation_domain']
+                : $options['btn_catalogue'];
         $view->vars['btn_catalogue'] = $options['btn_catalogue'];
     }
 
@@ -50,15 +57,30 @@ final class CollectionType extends AbstractType
             'type_options' => [],
             'pre_bind_data_callback' => null,
             'btn_add' => 'link_add',
-            'btn_catalogue' => 'SonataFormBundle',
+            'btn_catalogue' => 'SonataFormBundle', // NEXT_MAJOR: Remove this option.
+            'btn_translation_domain' => 'SonataFormBundle',
         ]);
+
+        $resolver->setDeprecated(
+            'btn_catalogue',
+            'sonata-project/form-extensions',
+            '2.1',
+            static function (Options $options, mixed $value): string {
+                if ('SonataFormBundle' !== $value) {
+                    return 'Passing a value to option "btn_catalogue" is deprecated! Use "btn_translation_domain" instead!';
+                }
+
+                return '';
+            },
+        ); // NEXT_MAJOR: Remove this deprecation notice.
 
         $resolver->setAllowedTypes('modifiable', 'bool');
         $resolver->setAllowedTypes('type', 'string');
         $resolver->setAllowedTypes('type_options', 'array');
         $resolver->setAllowedTypes('pre_bind_data_callback', ['null', 'callable']);
-        $resolver->setAllowedTypes('btn_add', ['null', 'string']);
-        $resolver->setAllowedTypes('btn_catalogue', ['null', 'string']);
+        $resolver->setAllowedTypes('btn_add', ['null', 'bool', 'string']);
+        $resolver->setAllowedTypes('btn_catalogue', ['null', 'bool', 'string']);
+        $resolver->setAllowedTypes('btn_translation_domain', ['null', 'bool', 'string']);
     }
 
     public function getBlockPrefix(): string


### PR DESCRIPTION
## Subject

I am targeting this branch, because {reason}.

Closes #{put_issue_number_here}.

## Changelog

```markdown
### Added
- CollectionType btn_translation_domain option

### Deprecated
- CollectionType btn_catalogue option

### Fixed
- CollectionType btn_add allowed types
```
