### PR TITLE
DateTimePickerType: added missing useTwentyfourHour display option

### DIFF
--- a/src/Type/BasePickerType.php
+++ b/src/Type/BasePickerType.php
@@ -67,6 +67,7 @@ abstract class BasePickerType extends AbstractType implements LocaleAwareInterfa
      */
     private const LOCALIZATION_OPTIONS = [
         'locale' => 'string',
+        'hourCycle' => 'string',
     ];
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Added missing `hourCycle` localization option for DateTimePickerType. So we can override the setting defined by a given locale.
See: https://getdatepicker.com/6/options/localization.html#hourCycle


<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - 3.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/form-extensions/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because its a bugfix.

## Changelog

```markdown
### Added
- missing `hourCycle` localization option for DateTimePickerType
```
