### PR TITLE
Fix deprecated use of `OptionsResolver::setDefault()`

### DIFF
--- a/src/Type/BasePickerType.php
+++ b/src/Type/BasePickerType.php
@@ -142,7 +142,13 @@ abstract class BasePickerType extends AbstractType implements LocaleAwareInterfa
     {
         $resolver->setDefaults($this->getCommonDefaults());
 
+        /**
+         * TODO: use `setOptions` directly once we drop support for Symfony < 7.3.
+         *
+         * @phpstan-ignore function.alreadyNarrowedType
+         */
         $resolverSetOptionsMethod = method_exists($resolver, 'setOptions') ? 'setOptions' : 'setDefault';
+        /* @phpstan-ignore method.dynamicName */
         $resolver->{$resolverSetOptionsMethod}('datepicker_options', function (OptionsResolver $datePickerResolver) use ($resolverSetOptionsMethod) {
             $datePickerResolver->setDefined(array_keys(self::DATEPICKER_ALLOWED_OPTIONS));
 
@@ -156,8 +162,11 @@ abstract class BasePickerType extends AbstractType implements LocaleAwareInterfa
             $defaults = $this->getCommonDatepickerDefaults();
 
             $datePickerResolver->setDefaults($defaults);
+            /* @phpstan-ignore method.dynamicName */
             $datePickerResolver->{$resolverSetOptionsMethod}('localization', $this->defineLocalizationOptions($defaults['localization'] ?? []));
+            /* @phpstan-ignore method.dynamicName */
             $datePickerResolver->{$resolverSetOptionsMethod}('restrictions', $this->defineRestrictionsOptions($defaults['restrictions'] ?? []));
+            /* @phpstan-ignore method.dynamicName */
             $datePickerResolver->{$resolverSetOptionsMethod}('display', $this->defineDisplayOptions($defaults['display'] ?? []));
         });
 
@@ -263,11 +272,11 @@ abstract class BasePickerType extends AbstractType implements LocaleAwareInterfa
     /**
      * @param array<string, mixed> $defaults
      *
-     * @return \Closure(OptionsResolver, Options): void
+     * @return \Closure(OptionsResolver): void
      */
     private function defineLocalizationOptions(array $defaults): callable
     {
-        return static function (OptionsResolver $resolver, Options $options) use ($defaults): void {
+        return static function (OptionsResolver $resolver) use ($defaults): void {
             $resolver->setDefined(array_keys(self::LOCALIZATION_OPTIONS));
 
             foreach (self::LOCALIZATION_OPTIONS as $option => $allowedTypes) {
@@ -281,11 +290,11 @@ abstract class BasePickerType extends AbstractType implements LocaleAwareInterfa
     /**
      * @param array<string, mixed> $defaults
      *
-     * @return \Closure(OptionsResolver, Options): void
+     * @return \Closure(OptionsResolver): void
      */
     private function defineRestrictionsOptions(array $defaults): callable
     {
-        return function (OptionsResolver $resolver, Options $options) use ($defaults): void {
+        return function (OptionsResolver $resolver) use ($defaults): void {
             $resolver->setDefined(array_keys(self::RESTRICTIONS_OPTIONS));
 
             foreach (self::RESTRICTIONS_OPTIONS as $option => $allowedTypes) {
@@ -328,11 +337,11 @@ abstract class BasePickerType extends AbstractType implements LocaleAwareInterfa
     /**
      * @param array<string, mixed> $defaults
      *
-     * @return \Closure(OptionsResolver, Options): void
+     * @return \Closure(OptionsResolver): void
      */
     private function defineDisplayOptions(array $defaults): callable
     {
-        return function (OptionsResolver $resolver, Options $options) use ($defaults): void {
+        return function (OptionsResolver $resolver) use ($defaults): void {
             $resolver->setDefined(array_keys(self::DISPLAY_OPTIONS));
 
             foreach (self::DISPLAY_OPTIONS as $option => $allowedTypes) {
@@ -344,9 +353,21 @@ abstract class BasePickerType extends AbstractType implements LocaleAwareInterfa
             $resolver->setAllowedValues('theme', ['light', 'dark', 'auto']);
 
             $resolver->setDefaults($defaults);
+
+            /**
+             * TODO: use `setOptions` directly once we drop support for Symfony < 7.3.
+             *
+             * @psalm-suppress RedundantCondition
+             *
+             * @phpstan-ignore function.alreadyNarrowedType
+             */
             $resolverSetOptionsMethod = method_exists($resolver, 'setOptions') ? 'setOptions' : 'setDefault';
+
+            /* @phpstan-ignore method.dynamicName */
             $resolver->{$resolverSetOptionsMethod}('icons', $this->defineDisplayIconsOptions($defaults['icons'] ?? []));
+            /* @phpstan-ignore method.dynamicName */
             $resolver->{$resolverSetOptionsMethod}('buttons', $this->defineDisplayButtonsOptions($defaults['buttons'] ?? []));
+            /* @phpstan-ignore method.dynamicName */
             $resolver->{$resolverSetOptionsMethod}('components', $this->defineDisplayComponentsOptions($defaults['components'] ?? []));
         };
     }
@@ -354,11 +375,11 @@ abstract class BasePickerType extends AbstractType implements LocaleAwareInterfa
     /**
      * @param array<string, mixed> $defaults
      *
-     * @return \Closure(OptionsResolver, Options): void
+     * @return \Closure(OptionsResolver): void
      */
     private function defineDisplayIconsOptions(array $defaults): callable
     {
-        return static function (OptionsResolver $resolver, Options $options) use ($defaults): void {
+        return static function (OptionsResolver $resolver) use ($defaults): void {
             $resolver->setDefined(array_keys(self::DISPLAY_ICONS_OPTIONS));
 
             foreach (self::DISPLAY_ICONS_OPTIONS as $option => $allowedTypes) {
@@ -372,11 +393,11 @@ abstract class BasePickerType extends AbstractType implements LocaleAwareInterfa
     /**
      * @param array<string, mixed> $defaults
      *
-     * @return \Closure(OptionsResolver, Options): void
+     * @return \Closure(OptionsResolver): void
      */
     private function defineDisplayButtonsOptions(array $defaults): callable
     {
-        return static function (OptionsResolver $resolver, Options $options) use ($defaults): void {
+        return static function (OptionsResolver $resolver) use ($defaults): void {
             $resolver->setDefined(array_keys(self::DISPLAY_BUTTONS_OPTIONS));
 
             foreach (self::DISPLAY_BUTTONS_OPTIONS as $option => $allowedTypes) {
@@ -390,11 +411,11 @@ abstract class BasePickerType extends AbstractType implements LocaleAwareInterfa
     /**
      * @param array<string, mixed> $defaults
      *
-     * @return \Closure(OptionsResolver, Options): void
+     * @return \Closure(OptionsResolver): void
      */
     private function defineDisplayComponentsOptions(array $defaults): callable
     {
-        return static function (OptionsResolver $resolver, Options $options) use ($defaults): void {
+        return static function (OptionsResolver $resolver) use ($defaults): void {
             $resolver->setDefined(array_keys(self::DISPLAY_COMPONENTS_OPTIONS));
 
             foreach (self::DISPLAY_COMPONENTS_OPTIONS as $option => $allowedTypes) {

--- a/src/Type/BasePickerType.php
+++ b/src/Type/BasePickerType.php
@@ -142,7 +142,8 @@ abstract class BasePickerType extends AbstractType implements LocaleAwareInterfa
     {
         $resolver->setDefaults($this->getCommonDefaults());
 
-        $resolver->setDefault('datepicker_options', function (OptionsResolver $datePickerResolver) {
+        $resolverSetOptionsMethod = method_exists($resolver, 'setOptions') ? 'setOptions' : 'setDefault';
+        $resolver->{$resolverSetOptionsMethod}('datepicker_options', function (OptionsResolver $datePickerResolver) use ($resolverSetOptionsMethod) {
             $datePickerResolver->setDefined(array_keys(self::DATEPICKER_ALLOWED_OPTIONS));
 
             foreach (self::DATEPICKER_ALLOWED_OPTIONS as $option => $allowedTypes) {
@@ -155,9 +156,9 @@ abstract class BasePickerType extends AbstractType implements LocaleAwareInterfa
             $defaults = $this->getCommonDatepickerDefaults();
 
             $datePickerResolver->setDefaults($defaults);
-            $datePickerResolver->setDefault('localization', $this->defineLocalizationOptions($defaults['localization'] ?? []));
-            $datePickerResolver->setDefault('restrictions', $this->defineRestrictionsOptions($defaults['restrictions'] ?? []));
-            $datePickerResolver->setDefault('display', $this->defineDisplayOptions($defaults['display'] ?? []));
+            $datePickerResolver->{$resolverSetOptionsMethod}('localization', $this->defineLocalizationOptions($defaults['localization'] ?? []));
+            $datePickerResolver->{$resolverSetOptionsMethod}('restrictions', $this->defineRestrictionsOptions($defaults['restrictions'] ?? []));
+            $datePickerResolver->{$resolverSetOptionsMethod}('display', $this->defineDisplayOptions($defaults['display'] ?? []));
         });
 
         $resolver->setNormalizer(
@@ -261,10 +262,12 @@ abstract class BasePickerType extends AbstractType implements LocaleAwareInterfa
 
     /**
      * @param array<string, mixed> $defaults
+     *
+     * @return \Closure(OptionsResolver, Options): void
      */
     private function defineLocalizationOptions(array $defaults): callable
     {
-        return static function (OptionsResolver $resolver) use ($defaults): void {
+        return static function (OptionsResolver $resolver, Options $options) use ($defaults): void {
             $resolver->setDefined(array_keys(self::LOCALIZATION_OPTIONS));
 
             foreach (self::LOCALIZATION_OPTIONS as $option => $allowedTypes) {
@@ -277,10 +280,12 @@ abstract class BasePickerType extends AbstractType implements LocaleAwareInterfa
 
     /**
      * @param array<string, mixed> $defaults
+     *
+     * @return \Closure(OptionsResolver, Options): void
      */
     private function defineRestrictionsOptions(array $defaults): callable
     {
-        return function (OptionsResolver $resolver) use ($defaults): void {
+        return function (OptionsResolver $resolver, Options $options) use ($defaults): void {
             $resolver->setDefined(array_keys(self::RESTRICTIONS_OPTIONS));
 
             foreach (self::RESTRICTIONS_OPTIONS as $option => $allowedTypes) {
@@ -322,10 +327,12 @@ abstract class BasePickerType extends AbstractType implements LocaleAwareInterfa
 
     /**
      * @param array<string, mixed> $defaults
+     *
+     * @return \Closure(OptionsResolver, Options): void
      */
     private function defineDisplayOptions(array $defaults): callable
     {
-        return function (OptionsResolver $resolver) use ($defaults): void {
+        return function (OptionsResolver $resolver, Options $options) use ($defaults): void {
             $resolver->setDefined(array_keys(self::DISPLAY_OPTIONS));
 
             foreach (self::DISPLAY_OPTIONS as $option => $allowedTypes) {
@@ -337,18 +344,21 @@ abstract class BasePickerType extends AbstractType implements LocaleAwareInterfa
             $resolver->setAllowedValues('theme', ['light', 'dark', 'auto']);
 
             $resolver->setDefaults($defaults);
-            $resolver->setDefault('icons', $this->defineDisplayIconsOptions($defaults['icons'] ?? []));
-            $resolver->setDefault('buttons', $this->defineDisplayButtonsOptions($defaults['buttons'] ?? []));
-            $resolver->setDefault('components', $this->defineDisplayComponentsOptions($defaults['components'] ?? []));
+            $resolverSetOptionsMethod = method_exists($resolver, 'setOptions') ? 'setOptions' : 'setDefault';
+            $resolver->{$resolverSetOptionsMethod}('icons', $this->defineDisplayIconsOptions($defaults['icons'] ?? []));
+            $resolver->{$resolverSetOptionsMethod}('buttons', $this->defineDisplayButtonsOptions($defaults['buttons'] ?? []));
+            $resolver->{$resolverSetOptionsMethod}('components', $this->defineDisplayComponentsOptions($defaults['components'] ?? []));
         };
     }
 
     /**
      * @param array<string, mixed> $defaults
+     *
+     * @return \Closure(OptionsResolver, Options): void
      */
     private function defineDisplayIconsOptions(array $defaults): callable
     {
-        return static function (OptionsResolver $resolver) use ($defaults): void {
+        return static function (OptionsResolver $resolver, Options $options) use ($defaults): void {
             $resolver->setDefined(array_keys(self::DISPLAY_ICONS_OPTIONS));
 
             foreach (self::DISPLAY_ICONS_OPTIONS as $option => $allowedTypes) {
@@ -361,10 +371,12 @@ abstract class BasePickerType extends AbstractType implements LocaleAwareInterfa
 
     /**
      * @param array<string, mixed> $defaults
+     *
+     * @return \Closure(OptionsResolver, Options): void
      */
     private function defineDisplayButtonsOptions(array $defaults): callable
     {
-        return static function (OptionsResolver $resolver) use ($defaults): void {
+        return static function (OptionsResolver $resolver, Options $options) use ($defaults): void {
             $resolver->setDefined(array_keys(self::DISPLAY_BUTTONS_OPTIONS));
 
             foreach (self::DISPLAY_BUTTONS_OPTIONS as $option => $allowedTypes) {
@@ -377,10 +389,12 @@ abstract class BasePickerType extends AbstractType implements LocaleAwareInterfa
 
     /**
      * @param array<string, mixed> $defaults
+     *
+     * @return \Closure(OptionsResolver, Options): void
      */
     private function defineDisplayComponentsOptions(array $defaults): callable
     {
-        return static function (OptionsResolver $resolver) use ($defaults): void {
+        return static function (OptionsResolver $resolver, Options $options) use ($defaults): void {
             $resolver->setDefined(array_keys(self::DISPLAY_COMPONENTS_OPTIONS));
 
             foreach (self::DISPLAY_COMPONENTS_OPTIONS as $option => $allowedTypes) {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - 3.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/form-extensions/blob/2.x/CONTRIBUTING.md#base-branch
-->

Closes #540

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/form-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Fixed
- Replace deprecated use of `OptionsResolver::setDefault()` by `OptionsResolver::setOptions()`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
