### PR TITLE
fix Symfony validation constraint deprecations

### DIFF
--- a/src/Validator/ErrorElement.php
+++ b/src/Validator/ErrorElement.php
@@ -256,6 +256,16 @@ final class ErrorElement
             ));
         }
 
+        $constructorArgumentNames = array_map(
+            static fn (\ReflectionParameter $parameter) => $parameter->name,
+            (new \ReflectionClass($className))->getConstructor()?->getParameters() ?? [],
+        );
+
+        if ([] === array_diff_key($options, array_flip($constructorArgumentNames))) {
+            return new $className(...$options);
+        }
+
+        // this will either trigger Symfony deprecations on 7.3|7.4 or fail entirely on Symfony 8
         return new $className($options);
     }
 

--- a/src/Validator/ErrorElement.php
+++ b/src/Validator/ErrorElement.php
@@ -256,17 +256,7 @@ final class ErrorElement
             ));
         }
 
-        $constructorArgumentNames = array_map(
-            static fn (\ReflectionParameter $parameter) => $parameter->name,
-            (new \ReflectionClass($className))->getConstructor()?->getParameters() ?? [],
-        );
-
-        if ([] === array_diff_key($options, array_flip($constructorArgumentNames))) {
-            return new $className(...$options);
-        }
-
-        // this will either trigger Symfony deprecations on 7.3|7.4 or fail entirely on Symfony 8
-        return new $className($options);
+        return new $className(...$options);
     }
 
     private function getCurrentPropertyPath(): ?PropertyPathInterface

--- a/tests/Validator/ErrorElementTest.php
+++ b/tests/Validator/ErrorElementTest.php
@@ -13,12 +13,14 @@ declare(strict_types=1);
 
 namespace Sonata\Form\Tests\Validator;
 
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sonata\Form\Tests\Fixtures\Bundle\Entity\Foo;
 use Sonata\Form\Validator\ErrorElement;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Exception\InvalidOptionsException;
 use Symfony\Component\Validator\Validator\ContextualValidatorInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
@@ -136,6 +138,16 @@ final class ErrorElementTest extends TestCase
         $this->errorElement->with('bar');
         $this->errorElement->assertNotNull();
         $this->errorElement->end();
+    }
+
+    #[IgnoreDeprecations]
+    public function testAsserCallWithInvalidOption(): void
+    {
+        self::expectException(InvalidOptionsException::class);
+
+        $this->errorElement->assertNotNull([
+            'foo' => 'bar',
+        ]);
     }
 
     /**

--- a/tests/Validator/ErrorElementTest.php
+++ b/tests/Validator/ErrorElementTest.php
@@ -13,14 +13,12 @@ declare(strict_types=1);
 
 namespace Sonata\Form\Tests\Validator;
 
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sonata\Form\Tests\Fixtures\Bundle\Entity\Foo;
 use Sonata\Form\Validator\ErrorElement;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
-use Symfony\Component\Validator\Exception\InvalidOptionsException;
 use Symfony\Component\Validator\Validator\ContextualValidatorInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
@@ -140,10 +138,9 @@ final class ErrorElementTest extends TestCase
         $this->errorElement->end();
     }
 
-    #[IgnoreDeprecations]
     public function testAsserCallWithInvalidOption(): void
     {
-        self::expectException(InvalidOptionsException::class);
+        self::expectExceptionMessage('Unknown named parameter $foo');
 
         $this->errorElement->assertNotNull([
             'foo' => 'bar',


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - 3.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/form-extensions/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because its BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/form-extensions/issues/548

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/form-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Fixed
- Symfony 7.3 deprecations for constraint constructor options array usage
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
