### PR TITLE
Fix Symfony 7.4 validator constraint deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "homepage": "https://docs.sonata-project.org/projects/form-extensions",
     "require": {
         "php": "^8.1",
+        "symfony/deprecation-contracts": "^3.6",
         "symfony/event-dispatcher": "^6.4 || ^7.1",
         "symfony/form": "^6.4 || ^7.1",
         "symfony/options-resolver": "^6.4 || ^7.1",

--- a/src/Test/AbstractWidgetTestCase.php
+++ b/src/Test/AbstractWidgetTestCase.php
@@ -85,7 +85,7 @@ abstract class AbstractWidgetTestCase extends TypeTestCase
             __DIR__.'/../../vendor/symfony/symfony/src/Symfony/Bridge/Twig/Resources/views/Form',
             // symfony/symfony (running from other bundles)
             __DIR__.'/../../../../symfony/symfony/src/Symfony/Bridge/Twig/Resources/views/Form',
-        ], 'is_dir');
+        ], is_dir(...));
 
         $twigPaths[] = __DIR__.'/../Bridge/Symfony/Resources/views/Form';
 

--- a/src/Validator/Constraints/InlineConstraint.php
+++ b/src/Validator/Constraints/InlineConstraint.php
@@ -27,17 +27,15 @@ use Symfony\Component\Validator\Exception\MissingOptionsException;
  */
 final class InlineConstraint extends Constraint
 {
-    protected mixed $service = null;
-
     /**
      * @param array<string, mixed>|null $options
      */
     public function __construct(
-        mixed $service = null,
-        protected mixed $method = null,
-        protected bool $serializingWarning = false,
+        protected mixed $service = null, // NEXT_MAJOR: make private and non-nullable (and narrow the type?)
+        protected mixed $method = null, // NEXT_MAJOR: make private and non-nullable (and narrow the type?)
+        protected bool $serializingWarning = false, // NEXT_MAJOR: make private
         ?array $groups = null,
-        ?array $options = null,
+        ?array $options = null, // NEXT_MAJOR: remove
     ) {
         if (\is_array($service) || \is_array($options)) {
             trigger_deprecation(
@@ -73,12 +71,13 @@ final class InlineConstraint extends Constraint
         }
     }
 
+    // TODO: remove when support for Symfony < 7.4 is dropped
     public function __sleep(): array
     {
         // @phpstan-ignore-next-line to initialize "groups" option if it is not set
         $this->groups;
 
-        if (!\is_string($this->service) || !\is_string($this->method)) {
+        if (!\is_string($this->getService()) || !\is_string($this->getMethod())) {
             return [];
         }
 
@@ -87,7 +86,7 @@ final class InlineConstraint extends Constraint
 
     public function __serialize(): array
     {
-        if (!\is_string($this->service) || !\is_string($this->method)) {
+        if (!\is_string($this->getService()) || !\is_string($this->getMethod())) {
             return [];
         }
 
@@ -96,7 +95,7 @@ final class InlineConstraint extends Constraint
 
     public function __wakeup(): void
     {
-        if (\is_string($this->service) && \is_string($this->method)) {
+        if (\is_string($this->getService()) && \is_string($this->getMethod())) {
             return;
         }
 
@@ -113,12 +112,12 @@ final class InlineConstraint extends Constraint
 
     public function isClosure(): bool
     {
-        return $this->method instanceof \Closure;
+        return $this->getMethod() instanceof \Closure;
     }
 
     public function getClosure(): mixed
     {
-        return $this->method;
+        return $this->method ?? null;
     }
 
     public function getTargets(): string
@@ -128,12 +127,12 @@ final class InlineConstraint extends Constraint
 
     public function getMethod(): mixed
     {
-        return $this->method;
+        return $this->method ?? null;
     }
 
     public function getService(): mixed
     {
-        return $this->service;
+        return $this->service ?? null;
     }
 
     public function getSerializingWarning(): bool

--- a/src/Validator/Constraints/InlineConstraint.php
+++ b/src/Validator/Constraints/InlineConstraint.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\Form\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\MissingOptionsException;
 
 /**
  * Constraint which allows inline-validation inside services.
@@ -28,13 +29,42 @@ final class InlineConstraint extends Constraint
 {
     protected mixed $service = null;
 
-    protected mixed $method = null;
+    /**
+     * @param array<string, mixed>|null $options
+     */
+    public function __construct(
+        mixed $service = null,
+        protected mixed $method = null,
+        protected bool $serializingWarning = false,
+        ?array $groups = null,
+        ?array $options = null,
+    ) {
+        if (\is_array($service) || \is_array($options)) {
+            trigger_deprecation(
+                'sonata-project/form-extensions',
+                '2.6.0',
+                'Passing an array of options to configure the "%s" constraint is deprecated. Use named arguments instead.',
+                self::class,
+            );
 
-    protected bool $serializingWarning = false;
+            $options ??= [];
+            if (!\is_array($service)) {
+                $this->service = $service;
+            } else {
+                $options = array_merge($options, $service);
+            }
+            parent::__construct($options, groups: $groups);
+        } else {
+            $this->service = $service;
+            parent::__construct(groups: $groups);
+        }
 
-    public function __construct(mixed $options = null)
-    {
-        parent::__construct($options);
+        if (null === $this->service || null === $this->method) {
+            throw new MissingOptionsException(
+                \sprintf('The required options/arguments "service" and "method" must be set for constraint "%s"', self::class),
+                ['service', 'method'],
+            );
+        }
 
         if ((!\is_string($this->service) || !\is_string($this->method)) && true !== $this->serializingWarning) {
             throw new \RuntimeException('You are using a closure with the `InlineConstraint`, this constraint'.
@@ -53,6 +83,15 @@ final class InlineConstraint extends Constraint
         }
 
         return array_keys(get_object_vars($this));
+    }
+
+    public function __serialize(): array
+    {
+        if (!\is_string($this->service) || !\is_string($this->method)) {
+            return [];
+        }
+
+        return get_object_vars($this);
     }
 
     public function __wakeup(): void
@@ -85,14 +124,6 @@ final class InlineConstraint extends Constraint
     public function getTargets(): string
     {
         return self::CLASS_CONSTRAINT;
-    }
-
-    public function getRequiredOptions(): array
-    {
-        return [
-            'service',
-            'method',
-        ];
     }
 
     public function getMethod(): mixed

--- a/tests/Validator/Constraints/InlineConstraintTest.php
+++ b/tests/Validator/Constraints/InlineConstraintTest.php
@@ -104,6 +104,9 @@ final class InlineConstraintTest extends TestCase
         static::assertInstanceOf(\Closure::class, $constraint->getMethod());
         static::assertEmpty($constraint->getService());
         static::assertTrue($constraint->getSerializingWarning());
+
+        // serialize again gives the same
+        static::assertSame($expected, serialize($constraint));
     }
 
     public function testStandardSerialization(): void

--- a/tests/Validator/Constraints/InlineConstraintTest.php
+++ b/tests/Validator/Constraints/InlineConstraintTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\Form\Test\Validator\Constraints;
 
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Sonata\Form\Validator\Constraints\InlineConstraint;
 
@@ -21,19 +22,45 @@ use Sonata\Form\Validator\Constraints\InlineConstraint;
  */
 final class InlineConstraintTest extends TestCase
 {
+    #[IgnoreDeprecations]
+    public function testInstantiateWithDeprecatedOptionsArray(): void
+    {
+        $constraint = new InlineConstraint(['service' => 'foo', 'method' => 'bar', 'groups' => ['foo']]);
+        static::assertSame('foo', $constraint->getService());
+        static::assertSame('bar', $constraint->getMethod());
+        static::assertSame(['foo'], $constraint->groups);
+    }
+
+    #[IgnoreDeprecations]
+    public function testInstantiateWithDeprecatedNamedOptionsArray(): void
+    {
+        $constraint = new InlineConstraint(options: ['service' => 'foo', 'method' => 'bar', 'groups' => ['foo']]);
+        static::assertSame('foo', $constraint->getService());
+        static::assertSame('bar', $constraint->getMethod());
+        static::assertSame(['foo'], $constraint->groups);
+    }
+
+    public function testInstantiateWithNamedArgumentOptions(): void
+    {
+        $constraint = new InlineConstraint(service: 'foo', method: 'bar', serializingWarning: true, groups: ['foo']);
+        static::assertSame('foo', $constraint->getService());
+        static::assertSame('bar', $constraint->getMethod());
+        static::assertSame(['foo'], $constraint->groups);
+    }
+
     public function testValidatedBy(): void
     {
-        $constraint = new InlineConstraint(['service' => 'foo', 'method' => 'bar']);
+        $constraint = new InlineConstraint(service: 'foo', method: 'bar');
         static::assertSame('sonata.form.validator.inline', $constraint->validatedBy());
     }
 
     public function testIsClosure(): void
     {
-        $constraint = new InlineConstraint(['service' => 'foo', 'method' => 'bar']);
+        $constraint = new InlineConstraint(service: 'foo', method: 'bar');
         static::assertFalse($constraint->isClosure());
 
-        $constraint = new InlineConstraint(['service' => 'foo', 'method' => static function (): void {
-        }, 'serializingWarning' => true]);
+        $constraint = new InlineConstraint(service: 'foo', method: static function (): void {
+        }, serializingWarning: true);
         static::assertTrue($constraint->isClosure());
     }
 
@@ -41,38 +68,32 @@ final class InlineConstraintTest extends TestCase
     {
         $closure = static fn (): string => 'FOO';
 
-        $constraint = new InlineConstraint(['service' => 'foo', 'method' => $closure, 'serializingWarning' => true]);
+        $constraint = new InlineConstraint(service: 'foo', method: $closure, serializingWarning: true);
         static::assertSame($closure, $constraint->getClosure());
     }
 
     public function testGetTargets(): void
     {
-        $constraint = new InlineConstraint(['service' => 'foo', 'method' => 'bar']);
+        $constraint = new InlineConstraint(service: 'foo', method: 'bar');
         static::assertSame(InlineConstraint::CLASS_CONSTRAINT, $constraint->getTargets());
-    }
-
-    public function testGetRequiredOptions(): void
-    {
-        $constraint = new InlineConstraint(['service' => 'foo', 'method' => 'bar']);
-        static::assertSame(['service', 'method'], $constraint->getRequiredOptions());
     }
 
     public function testGetMethod(): void
     {
-        $constraint = new InlineConstraint(['service' => 'foo', 'method' => 'bar']);
+        $constraint = new InlineConstraint(service: 'foo', method: 'bar');
         static::assertSame('bar', $constraint->getMethod());
     }
 
     public function testGetService(): void
     {
-        $constraint = new InlineConstraint(['service' => 'foo', 'method' => 'bar']);
+        $constraint = new InlineConstraint(service: 'foo', method: 'bar');
         static::assertSame('foo', $constraint->getService());
     }
 
     public function testClosureSerialization(): void
     {
-        $constraint = new InlineConstraint(['service' => 'foo', 'method' => static function (): void {
-        }, 'serializingWarning' => true]);
+        $constraint = new InlineConstraint(service: 'foo', method: static function (): void {
+        }, serializingWarning: true);
 
         $expected = 'O:50:"Sonata\Form\Validator\Constraints\InlineConstraint":0:{}';
 
@@ -87,14 +108,16 @@ final class InlineConstraintTest extends TestCase
 
     public function testStandardSerialization(): void
     {
-        $constraint = new InlineConstraint(['service' => 'foo', 'method' => 'bar']);
+        $constraint = new InlineConstraint(service: 'foo', method: 'bar', groups: ['foo']);
 
         $data = serialize($constraint);
 
+        /** @var InlineConstraint $constraint */
         $constraint = unserialize($data);
 
         static::assertSame('foo', $constraint->getService());
         static::assertSame('bar', $constraint->getMethod());
+        static::assertSame(['foo'], $constraint->groups);
         static::assertFalse($constraint->getSerializingWarning());
     }
 
@@ -107,7 +130,7 @@ final class InlineConstraintTest extends TestCase
             ' Once done, you can set the `serializingWarning` option to `true` to avoid this message.'
         );
 
-        new InlineConstraint(['service' => 1, 'method' => 'foo', 'serializingWarning' => false]);
+        new InlineConstraint(service: 1, method: 'foo', serializingWarning: false);
     }
 
     public function testSerializingWarningIsFalseWithMethodIsNotString(): void
@@ -119,6 +142,6 @@ final class InlineConstraintTest extends TestCase
             ' Once done, you can set the `serializingWarning` option to `true` to avoid this message.'
         );
 
-        new InlineConstraint(['service' => 'foo', 'method' => 1, 'serializingWarning' => false]);
+        new InlineConstraint(service: 'foo', method: 1, serializingWarning: false);
     }
 }

--- a/tests/Validator/InlineValidatorTest.php
+++ b/tests/Validator/InlineValidatorTest.php
@@ -66,13 +66,13 @@ final class InlineValidatorTest extends TestCase
         $this->expectException(ValidatorException::class);
         $this->expectExceptionMessage('foo is equal to foo');
 
-        $constraint = new InlineConstraint([
-            'method' => static function (ErrorElement $errorElement, string $value): void {
+        $constraint = new InlineConstraint(
+            service: '',
+            method: static function (ErrorElement $errorElement, string $value): void {
                 throw new ValidatorException($errorElement->getSubject().' is equal to '.$value);
             },
-            'service' => '',
-            'serializingWarning' => true,
-        ]);
+            serializingWarning: true,
+        );
 
         $inlineValidator = new InlineValidator($this->container);
 
@@ -83,10 +83,10 @@ final class InlineValidatorTest extends TestCase
 
     public function testValidateWithConstraintGetServiceIsString(): void
     {
-        $constraint = new InlineConstraint([
-            'method' => 'fooValidatorMethod',
-            'service' => 'string',
-        ]);
+        $constraint = new InlineConstraint(
+            service: 'string',
+            method: 'fooValidatorMethod',
+        );
 
         $this->container->expects(static::once())
             ->method('get')
@@ -105,11 +105,11 @@ final class InlineValidatorTest extends TestCase
 
     public function testValidateWithConstraintGetServiceIsNotString(): void
     {
-        $constraint = new InlineConstraint([
-            'method' => 'fooValidatorMethod',
-            'service' => new FooValidatorService(),
-            'serializingWarning' => true,
-        ]);
+        $constraint = new InlineConstraint(
+            service: new FooValidatorService(),
+            method: 'fooValidatorMethod',
+            serializingWarning: true,
+        );
 
         $inlineValidator = new InlineValidator($this->container);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - 3.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/form-extensions/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because its BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

This is needed for Symfony 8 compatibility. Fixes this deprecation:
```
Since symfony/validator 7.4: Support for evaluating options in the base Constraint class is deprecated. Initialize properties in the constructor of Sonata\Form\Validator\Constraints\InlineConstraint instead.
``` 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/form-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Deprecated
- passing an array of options to `InlineConstraint::__construct` is deprecated. Use named arguments instead.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
