### PR TITLE
add #[HasNamedArguments] attr for InlineConstraint::__construct

### DIFF
--- a/src/Validator/Constraints/InlineConstraint.php
+++ b/src/Validator/Constraints/InlineConstraint.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\Form\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\MissingOptionsException;
 
@@ -30,6 +31,7 @@ final class InlineConstraint extends Constraint
     /**
      * @param array<string, mixed>|null $options
      */
+    #[HasNamedArguments]
     public function __construct(
         protected mixed $service = null, // NEXT_MAJOR: make private and non-nullable (and narrow the type?)
         protected mixed $method = null, // NEXT_MAJOR: make private and non-nullable (and narrow the type?)


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - 3.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/form-extensions/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because its BC.

Then no changes on MediaBundle + PageBundle needed as its instantiated using named arguments then. 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/form-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Added
- add `#[HasNamedArguments]` for `InlineConstraint::__construct`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
