### PR TITLE
improve test cases after allowing "ca" locale

### DIFF
--- a/assets/js/controllers/datepicker_controller.test.js
+++ b/assets/js/controllers/datepicker_controller.test.js
@@ -189,14 +189,14 @@ describe('DatepickerController', () => {
         id="datepicker"
         data-controller="datepicker"
         data-datepicker-options-value='${JSON.stringify({
-          localization: { locale: 'ca' },
+          localization: { locale: 'zh' },
         })}'
         data-td-target-input="nearest"
         data-td-target-toggle="nearest"
       >${innerDatepickerTest}</div>
     `);
 
-    expect(datePicker.optionsStore.options.localization.locale).toBe('ca');
+    expect(datePicker.optionsStore.options.localization.locale).toBe('zh');
 
     const icon = getByTestId(document, 'icon');
 
@@ -208,7 +208,7 @@ describe('DatepickerController', () => {
 
     expect(tempusDominusCalendar().querySelector('.picker-switch')).toHaveProperty(
       'title',
-      'Seleccionar mes'
+      'Select Month'
     );
   });
 
@@ -218,14 +218,14 @@ describe('DatepickerController', () => {
         id="datepicker"
         data-controller="datepicker"
         data-datepicker-options-value='${JSON.stringify({
-          localization: { locale: 'ca-ES' },
+          localization: { locale: 'zh-CN' },
         })}'
         data-td-target-input="nearest"
         data-td-target-toggle="nearest"
       >${innerDatepickerTest}</div>
     `);
 
-    expect(datePicker.optionsStore.options.localization.locale).toBe('ca-ES');
+    expect(datePicker.optionsStore.options.localization.locale).toBe('zh-CN');
 
     const icon = getByTestId(document, 'icon');
 
@@ -237,7 +237,7 @@ describe('DatepickerController', () => {
 
     expect(tempusDominusCalendar().querySelector('.picker-switch')).toHaveProperty(
       'title',
-      'Seleccionar mes'
+      'Select Month'
     );
   });
 


### PR DESCRIPTION
The tests are covering a case for a "not supported" locale. Previously `ca` was one of those and since #559 not anymore. So let's improve the test and use a different "not supported" locale. 